### PR TITLE
update travis file for composer work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: php
 
-before_script:
-  - composer self-update
-  - composer install --no-interaction --prefer-source --dev
+install:
+  - travis_retry composer install --no-interaction --prefer-source
 
 script: ./vendor/bin/phpunit --configuration ./build/travis-ci.xml
 
@@ -22,4 +21,3 @@ notifications:
     on_success: always
     on_failure: always
     on_start: false
-


### PR DESCRIPTION
- install deps in install section
- no need to self-update the composer
- no need for --dev as it is by default
- install deps using travis_retry
