### PR TITLE
Fix error when comparing empty DOM nodes

### DIFF
--- a/src/DOMNodeComparator.php
+++ b/src/DOMNodeComparator.php
@@ -119,7 +119,7 @@ class DOMNodeComparator extends ObjectComparator
     private function nodeToText(DOMNode $node, $canonicalize, $ignoreCase)
     {
         if ($canonicalize) {
-            $canonicalizedNode = $node->C14N();
+            $canonicalizedNode = (string) $node->C14N();
             if ($canonicalizedNode !== "") {
                 $document = new DOMDocument;
                 $document->loadXML($canonicalizedNode);

--- a/src/DOMNodeComparator.php
+++ b/src/DOMNodeComparator.php
@@ -119,10 +119,13 @@ class DOMNodeComparator extends ObjectComparator
     private function nodeToText(DOMNode $node, $canonicalize, $ignoreCase)
     {
         if ($canonicalize) {
-            $document = new DOMDocument;
-            $document->loadXML($node->C14N());
+            $canonicalizedNode = $node->C14N();
+            if ($canonicalizedNode !== "") {
+                $document = new DOMDocument;
+                $document->loadXML($canonicalizedNode);
 
-            $node = $document;
+                $node = $document;
+            }
         }
 
         if ($node instanceof DOMDocument) {

--- a/tests/DOMNodeComparatorTest.php
+++ b/tests/DOMNodeComparatorTest.php
@@ -123,6 +123,9 @@ class DOMNodeComparatorTest extends \PHPUnit_Framework_TestCase
 
     public function assertEqualsFailsProvider()
     {
+        $emptyDocument = new DOMDocument;
+        $emptyTextNode = $emptyDocument->createTextNode('');
+
         return array(
           array(
             $this->createDOMDocument('<root></root>'),
@@ -143,6 +146,18 @@ class DOMNodeComparatorTest extends \PHPUnit_Framework_TestCase
           array(
             $this->createDOMDocument('<foo> bar </foo>'),
             $this->createDOMDocument('<foo> bir </foo>')
+          ),
+          array(
+            $this->createDOMDocument('<root></root>'),
+            $emptyDocument
+          ),
+          array(
+            $this->createDOMDocument('<root></root>'),
+            $emptyTextNode
+          ),
+          array(
+            $emptyDocument,
+            $emptyTextNode
           )
         );
     }

--- a/tests/DOMNodeComparatorTest.php
+++ b/tests/DOMNodeComparatorTest.php
@@ -90,6 +90,9 @@ class DOMNodeComparatorTest extends \PHPUnit_Framework_TestCase
 
     public function assertEqualsSucceedsProvider()
     {
+        $emptyDocument = new DOMDocument;
+        $emptyTextNode = $emptyDocument->createTextNode('');
+
         return array(
           array(
             $this->createDOMDocument('<root></root>'),
@@ -106,6 +109,14 @@ class DOMNodeComparatorTest extends \PHPUnit_Framework_TestCase
           array(
             $this->createDOMDocument("<root>\n  <child/>\n</root>"),
             $this->createDOMDocument('<root><child/></root>')
+          ),
+          array(
+            $emptyDocument,
+            $emptyDocument
+          ),
+          array(
+            $emptyTextNode,
+            $emptyTextNode
           ),
         );
     }


### PR DESCRIPTION
Without this PR, doing a comparison like

```
$emptyDoc = new DOMDocument;
$comparator->assertEquals($emptyDoc, $emptyDoc);
```

would fail with an error `DOMDocument::loadXML(): Empty string supplied as input` due to the canonicalization step. This PR skips the load-into-a-new-document step when the node canonicalizes to an empty string.

Tests are included.
