### PR TITLE
Support DateTimeInterface in DateTimeComparator

### DIFF
--- a/src/DateTimeComparator.php
+++ b/src/DateTimeComparator.php
@@ -11,7 +11,7 @@
 namespace SebastianBergmann\Comparator;
 
 /**
- * Compares DateTime instances for equality.
+ * Compares DateTimeInterface instances for equality.
  */
 class DateTimeComparator extends ObjectComparator
 {
@@ -24,7 +24,8 @@ class DateTimeComparator extends ObjectComparator
      */
     public function accepts($expected, $actual)
     {
-        return $expected instanceof \DateTime && $actual instanceof \DateTime;
+        return ($expected instanceof \DateTime || $expected instanceof \DateTimeInterface) &&
+            ($actual instanceof \DateTime || $actual instanceof \DateTimeInterface);
     }
 
     /**
@@ -64,16 +65,16 @@ class DateTimeComparator extends ObjectComparator
 
     /**
      * Returns an ISO 8601 formatted string representation of a datetime or
-     * 'Invalid DateTime object' if the provided DateTime was not properly
+     * 'Invalid DateTimeInterface object' if the provided DateTimeInterface was not properly
      * initialized.
      *
-     * @param  \DateTime $datetime
+     * @param  \DateTimeInterface $datetime
      * @return string
      */
-    protected function dateTimeToString(\DateTime $datetime)
+    protected function dateTimeToString($datetime)
     {
         $string = $datetime->format(\DateTime::ISO8601);
 
-        return $string ? $string : 'Invalid DateTime object';
+        return $string ? $string : 'Invalid DateTimeInterface object';
     }
 }

--- a/tests/DateTimeComparatorTest.php
+++ b/tests/DateTimeComparatorTest.php
@@ -11,6 +11,7 @@
 namespace SebastianBergmann\Comparator;
 
 use DateTime;
+use DateTimeImmutable;
 use DateTimeZone;
 
 /**
@@ -190,5 +191,26 @@ class DateTimeComparatorTest extends \PHPUnit_Framework_TestCase
           'Failed asserting that two DateTime objects are equal.'
         );
         $this->comparator->assertEquals($expected, $actual, $delta);
+    }
+
+    /**
+     * @requires PHP 5.5
+     * @covers   ::accepts
+     */
+    public function testAcceptsDateTimeInterface()
+    {
+        $this->assertTrue($this->comparator->accepts(new DateTime, new DateTimeImmutable));
+    }
+
+    /**
+     * @requires PHP 5.5
+     * @covers   ::assertEquals
+     */
+    public function testSupportsDateTimeInterface()
+    {
+        $this->comparator->assertEquals(
+          new DateTime('2013-03-29 04:13:35', new DateTimeZone('America/New_York')),
+          new DateTimeImmutable('2013-03-29 04:13:35', new DateTimeZone('America/New_York'))
+        );
     }
 }


### PR DESCRIPTION
DateTimeComparator is a great tool for comparing DateTime instances and very helpful in PHPUnit for providing assertEquals functionality for these objects.

The fact that it compares DT instances based on their actual represented time is great, because that is, what you usually want to compare in your tests (not that the DT instances are actually equal - meaning including the time zone etc.).

Currently there is one big drawback and that is no support for DateTimeInterface (hence also no support for DateTimeImmutable).

You can simply do 
```php
<?php
$this->assertEquals(
  new DateTime('2013-03-29T05:13:35-0600'),
  new DateTime('2013-03-29T05:13:35-0500')
);
```
but you cannot do
```php
<?php
$this->assertEquals(
  new DateTime('2013-03-29T05:13:35-0600'),
  new DateTimeImmutable('2013-03-29T05:13:35-0500')
);
```

I think this should be definitely supported for the sake of consistency and user expectations and this PR provides the support.

Implementation notes:
* Since the interfaces are not present before PHP 5.5 the tests were added as separate tests, not in current providers, so that they can be skipped nicely.
* I had to remove the `DateTime` typehint in `DateTimeComparator::dateTimeToString`, because otherwise it would be not compatible and `DateTimeInterface` cannot be required because of the older versions. I chose not to add any verification of the argument since this is a protected method, if you want me to check the argument and throw an exception (or something else, since there is already an error string returned?), just tell me.
* I am not sure if the string `'Invalid DateTime object'` returned from `DateTimeComparator::dateTimeToString` should be changed, because someone might consider it part of the interface (for representing error state), but again I think clarity is more important in this case.