### PR TITLE
Use new Travis infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+sudo: false
+
 install:
   - travis_retry composer install --no-interaction --prefer-source
 


### PR DESCRIPTION
Use new Travis infrastructure for builds, it is a lot faster and more reliable. Oficial upgrade page: [Migrating from legacy to container-based infrastructure](http://docs.travis-ci.com/user/migrating-from-legacy/).

For practical results you can see the difference for PR #18:

old infrastructure:
* https://travis-ci.org/sebastianbergmann/comparator/builds/71621859
* https://travis-ci.org/sebastianbergmann/comparator/builds/71593960
* https://travis-ci.org/sebastianbergmann/comparator/builds/71583832
* https://travis-ci.org/sebastianbergmann/comparator/builds/71579272
* ...

new infrastructure:
* https://travis-ci.org/sebastianbergmann/comparator/builds/71637062

Without this change I couldn't even get the build to complete after several retries (which took ages).