### PR TITLE
Make ComparisonFailure serializable so it plays nicer when run with process isolation

### DIFF
--- a/src/ComparisonFailure.php
+++ b/src/ComparisonFailure.php
@@ -15,7 +15,7 @@ use SebastianBergmann\Diff\Differ;
 /**
  * Thrown when an assertion for string equality failed.
  */
-class ComparisonFailure extends \RuntimeException
+class ComparisonFailure extends \PHPUnit_Framework_Exception
 {
     /**
      * Expected value of the retrieval which does not match $actual.
@@ -71,6 +71,8 @@ class ComparisonFailure extends \RuntimeException
         $this->expectedAsString = $expectedAsString;
         $this->actualAsString   = $actualAsString;
         $this->message          = $message;
+
+        parent::__construct($this->toString());
     }
 
     /**


### PR DESCRIPTION
Fixes https://github.com/sebastianbergmann/phpunit/issues/1515

> Exception "Serialization of 'Closure' is not allowed" when using assertEquals with processIsolation

Based on the suggestion of @romanga

> make ComparisonFailure to inherit from PHPUnit_Framework_Exception

@czenker his remark doesn't stand (any more) because Comparator already has a dependency on PHPUnit. He said:

> Yes it would (be an easier solution). But you would also create a dependency from the comperator package to the full phpunit package which seems a little overkill.
