### PR TITLE
Supress warning about blank xml document

### DIFF
--- a/src/DOMNodeComparator.php
+++ b/src/DOMNodeComparator.php
@@ -81,7 +81,7 @@ class DOMNodeComparator extends ObjectComparator
     {
         if ($canonicalize) {
             $document = new DOMDocument;
-            $document->loadXML($node->C14N());
+            @$document->loadXML($node->C14N());
 
             $node = $document;
         }


### PR DESCRIPTION
I was getting a warning message with phpspec and it was breaking my tests. This pull requests suppresses the PHP warning: `warning: DOMDocument::loadXML(): Empty string supplied as input in .../vendor/sebastian/comparator/src/DOMNodeComparator.php line 84`
