### PR TITLE
use strict equality for string comparison

### DIFF
--- a/src/ScalarComparator.php
+++ b/src/ScalarComparator.php
@@ -64,8 +64,9 @@ class ScalarComparator extends Comparator
             }
         }
 
-        if ($expectedToCompare != $actualToCompare) {
-            if (is_string($expected) && is_string($actual)) {
+        if (is_string($expected) && is_string($actual)) {
+            if ($expectedToCompare !== $actualToCompare) {
+
                 throw new ComparisonFailure(
                     $expected,
                     $actual,
@@ -75,6 +76,7 @@ class ScalarComparator extends Comparator
                     'Failed asserting that two strings are equal.'
                 );
             }
+        } elseif ($expectedToCompare != $actualToCompare) {
 
             throw new ComparisonFailure(
                 $expected,

--- a/tests/ScalarComparatorTest.php
+++ b/tests/ScalarComparatorTest.php
@@ -90,6 +90,7 @@ class ScalarComparatorTest extends \PHPUnit_Framework_TestCase
           array("string", "other string", $stringException),
           // https://github.com/sebastianbergmann/phpunit/issues/1023
           array('9E6666666','9E7777777', $stringException),
+          array('0001', '1', $stringException),
           array(new ClassWithToString, "does not match", $otherException),
           array("does not match", new ClassWithToString, $otherException),
           array(0, 'Foobar', $otherException),


### PR DESCRIPTION
Fixes scenario where numeric strings with leading zeroes are considered equal.