### PR TITLE
Check date serialization issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
+  - 7.1
   - hhvm
 
 notifications:

--- a/tests/DateTimeComparatorTest.php
+++ b/tests/DateTimeComparatorTest.php
@@ -213,4 +213,14 @@ class DateTimeComparatorTest extends \PHPUnit_Framework_TestCase
           new DateTimeImmutable('2013-03-29 04:13:35', new DateTimeZone('America/New_York'))
         );
     }
+    
+    /**
+     * @requires PHP 7.1
+     * @covers   ::assertEquals
+     */
+    public function testSerializedDataTimeNow()
+    {
+        $date = new DateTime();
+        $this->comparator->assertEquals($date, unserialize(serialize($date)));
+    }
 }


### PR DESCRIPTION
I have a https://github.com/sebastianbergmann/comparator/commit/250cecf913117c6bd547ca9aeb261525fcd10676 fix, but still

```
Failed asserting that two DateTime objects are equal.
--- Expected
+++ Actual
@@ @@
 2017-02-22T09:23:35.899639+0000
```

Not a PHP issue https://3v4l.org/3UmTE and not failing on Travis