### PR TITLE
Composer update to diff 2.0 breaks ComparisonFailure

### DIFF
--- a/src/ComparisonFailure.php
+++ b/src/ComparisonFailure.php
@@ -11,6 +11,7 @@
 namespace SebastianBergmann\Comparator;
 
 use SebastianBergmann\Diff\Differ;
+use SebastianBergmann\Diff\Output\DiffOnlyOutputBuilder;
 
 /**
  * Thrown when an assertion for string equality failed.
@@ -119,7 +120,8 @@ class ComparisonFailure extends \RuntimeException
             return '';
         }
 
-        $differ = new Differ("\n--- Expected\n+++ Actual\n");
+        $builder = new DiffOnlyOutputBuilder("\n--- Expected\n+++ Actual\n");
+        $differ = new Differ($builder);
 
         return $differ->diff($this->expectedAsString, $this->actualAsString);
     }


### PR DESCRIPTION
Composer update to diff 2.0 breaks ComparisonFailure.
Addresses this scenario:

```
2) Doctrine\Tests\ORM\Mapping\AnnotationDriverTest::testFetchOverrideMapping
PHP Fatal error:  Method PHPUnit\Framework\ExpectationFailedException::__toString() must not throw an exception, caught TypeError: Argument 1 passed to SebastianBergmann\Diff\Differ::__construct() must implement interface SebastianBergmann\Diff\Output\DiffOutputBuilderInterface or be null, string given, called in /Users/gblanco/workspaces/doctrine/orm/vendor/sebastian/comparator/src/ComparisonFailure.php on line 124 in /Users/gblanco/workspaces/doctrine/orm/vendor/phpunit/phpunit/src/TextUI/ResultPrinter.php on line 0
PHP Stack trace:
PHP   1. {main}() /Users/gblanco/workspaces/doctrine/orm/vendor/phpunit/phpunit/phpunit:0
PHP   2. PHPUnit\TextUI\Command::main() /Users/gblanco/workspaces/doctrine/orm/vendor/phpunit/phpunit/phpunit:53
PHP   3. PHPUnit\TextUI\Command->run() /Users/gblanco/workspaces/doctrine/orm/vendor/phpunit/phpunit/src/TextUI/Command.php:141
PHP   4. PHPUnit\TextUI\TestRunner->doRun() /Users/gblanco/workspaces/doctrine/orm/vendor/phpunit/phpunit/src/TextUI/Command.php:210
PHP   5. PHPUnit\TextUI\ResultPrinter->printResult() /Users/gblanco/workspaces/doctrine/orm/vendor/phpunit/phpunit/src/TextUI/TestRunner.php:543
PHP   6. PHPUnit\TextUI\ResultPrinter->printFailures() /Users/gblanco/workspaces/doctrine/orm/vendor/phpunit/phpunit/src/TextUI/ResultPrinter.php:199
PHP   7. PHPUnit\TextUI\ResultPrinter->printDefects() /Users/gblanco/workspaces/doctrine/orm/vendor/phpunit/phpunit/src/TextUI/ResultPrinter.php:300
PHP   8. PHPUnit\TextUI\ResultPrinter->printDefect() /Users/gblanco/workspaces/doctrine/orm/vendor/phpunit/phpunit/src/TextUI/ResultPrinter.php:243
PHP   9. PHPUnit\TextUI\ResultPrinter->printDefectTrace() /Users/gblanco/workspaces/doctrine/orm/vendor/phpunit/phpunit/src/TextUI/ResultPrinter.php:256

Fatal error: Method PHPUnit\Framework\ExpectationFailedException::__toString() must not throw an exception, caught TypeError: Argument 1 passed to SebastianBergmann\Diff\Differ::__construct() must implement interface SebastianBergmann\Diff\Output\DiffOutputBuilderInterface or be null, string given, called in /Users/gblanco/workspaces/doctrine/orm/vendor/sebastian/comparator/src/ComparisonFailure.php on line 124 in /Users/gblanco/workspaces/doctrine/orm/vendor/phpunit/phpunit/src/TextUI/ResultPrinter.php on line 0

Call Stack:
    0.0004     358656   1. {main}() /Users/gblanco/workspaces/doctrine/orm/vendor/phpunit/phpunit/phpunit:0
    0.0295    1051784   2. PHPUnit\TextUI\Command::main() /Users/gblanco/workspaces/doctrine/orm/vendor/phpunit/phpunit/phpunit:53
    0.0296    1051896   3. PHPUnit\TextUI\Command->run() /Users/gblanco/workspaces/doctrine/orm/vendor/phpunit/phpunit/src/TextUI/Command.php:141
    1.5138   36555536   4. PHPUnit\TextUI\TestRunner->doRun() /Users/gblanco/workspaces/doctrine/orm/vendor/phpunit/phpunit/src/TextUI/Command.php:210
   23.3682  144610688   5. PHPUnit\TextUI\ResultPrinter->printResult() /Users/gblanco/workspaces/doctrine/orm/vendor/phpunit/phpunit/src/TextUI/TestRunner.php:543
   23.3768  145228624   6. PHPUnit\TextUI\ResultPrinter->printFailures() /Users/gblanco/workspaces/doctrine/orm/vendor/phpunit/phpunit/src/TextUI/ResultPrinter.php:199
   23.3769  145228624   7. PHPUnit\TextUI\ResultPrinter->printDefects() /Users/gblanco/workspaces/doctrine/orm/vendor/phpunit/phpunit/src/TextUI/ResultPrinter.php:300
   23.3773  145228624   8. PHPUnit\TextUI\ResultPrinter->printDefect() /Users/gblanco/workspaces/doctrine/orm/vendor/phpunit/phpunit/src/TextUI/ResultPrinter.php:243
   23.3773  145228624   9. PHPUnit\TextUI\ResultPrinter->printDefectTrace() /Users/gblanco/workspaces/doctrine/orm/vendor/phpunit/phpunit/src/TextUI/ResultPrinter.php:256
```