### PR TITLE
ComparisonFailure - Use unified diff format

### DIFF
--- a/src/ComparisonFailure.php
+++ b/src/ComparisonFailure.php
@@ -11,7 +11,7 @@
 namespace SebastianBergmann\Comparator;
 
 use SebastianBergmann\Diff\Differ;
-use SebastianBergmann\Diff\Output\DiffOnlyOutputBuilder;
+use SebastianBergmann\Diff\Output\UnifiedDiffOutputBuilder;
 
 /**
  * Thrown when an assertion for string equality failed.
@@ -120,8 +120,7 @@ class ComparisonFailure extends \RuntimeException
             return '';
         }
 
-        $builder = new DiffOnlyOutputBuilder("\n--- Expected\n+++ Actual\n");
-        $differ  = new Differ($builder);
+        $differ = new Differ(new UnifiedDiffOutputBuilder("\n--- Expected\n+++ Actual\n"));
 
         return $differ->diff($this->expectedAsString, $this->actualAsString);
     }

--- a/tests/ComparisonFailureTest.php
+++ b/tests/ComparisonFailureTest.php
@@ -1,0 +1,58 @@
+<?php
+/*
+ * This file is part of the Comparator package.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SebastianBergmann\Comparator;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers SebastianBergmann\Comparator\ComparisonFailure
+ */
+final class ComparisonFailureTest extends TestCase
+{
+    public function testComparisonFailure()
+    {
+        $actual   = "\nB\n";
+        $expected = "\nA\n";
+        $message  = 'Test message';
+
+        $failure = new ComparisonFailure(
+            $expected,
+            $actual,
+            '|' . $expected,
+            '|' . $actual,
+            false,
+            $message
+        );
+
+        $this->assertSame($actual, $failure->getActual());
+        $this->assertSame($expected, $failure->getExpected());
+        $this->assertSame('|' . $actual, $failure->getActualAsString());
+        $this->assertSame('|' . $expected, $failure->getExpectedAsString());
+
+        $diff = '
+--- Expected
++++ Actual
+@@ @@
+ |
+-A
++B
+';
+        $this->assertSame($diff, $failure->getDiff());
+        $this->assertSame($message . $diff, $failure->toString());
+    }
+
+    public function testDiffNotPossible()
+    {
+        $failure = new ComparisonFailure('a', 'b', false, false, true, 'test');
+        $this->assertSame('', $failure->getDiff());
+        $this->assertSame('test', $failure->toString());
+    }
+}


### PR DESCRIPTION
Version 1 of this package used the normal udiff format, however master uses `diff only`.
This is not needed and I think was unintended. 

I just noticed v2 of this package is already released with the other output builder, making this PR a BC.