### PR TITLE
Fix comparison of DateTimeImmutable objects

### DIFF
--- a/src/DateTimeComparator.php
+++ b/src/DateTimeComparator.php
@@ -48,18 +48,18 @@ class DateTimeComparator extends ObjectComparator
 
         $delta = new \DateInterval(sprintf('PT%dS', abs($delta)));
 
-        $actualClone = clone $actual;
-        $actualClone->setTimezone(new \DateTimeZone('UTC'));
+        $actualClone = (clone $actual)
+            ->setTimezone(new \DateTimeZone('UTC'));
 
-        $expectedLower = clone $expected;
-        $expectedLower->setTimezone(new \DateTimeZone('UTC'));
-        $expectedLower->sub($delta);
+        $expectedLower = (clone $expected)
+            ->setTimezone(new \DateTimeZone('UTC'))
+            ->sub($delta);
 
-        $expectedUpper = clone $expected;
-        $expectedUpper->setTimezone(new \DateTimeZone('UTC'));
-        $expectedUpper->add($delta);
+        $expectedUpper = (clone $expected)
+            ->setTimezone(new \DateTimeZone('UTC'))
+            ->add($delta);
 
-        if ($actual < $expectedLower || $actual > $expectedUpper) {
+        if ($actualClone < $expectedLower || $actualClone > $expectedUpper) {
             throw new ComparisonFailure(
                 $expected,
                 $actual,

--- a/tests/DateTimeComparatorTest.php
+++ b/tests/DateTimeComparatorTest.php
@@ -47,100 +47,96 @@ class DateTimeComparatorTest extends TestCase
     public function assertEqualsSucceedsProvider()
     {
         return [
-          [
-            new DateTime('2013-03-29 04:13:35', new DateTimeZone('America/New_York')),
-            new DateTime('2013-03-29 04:13:35', new DateTimeZone('America/New_York'))
-          ],
-          [
-            new DateTime('2013-03-29 04:13:35', new DateTimeZone('America/New_York')),
-            new DateTime('2013-03-29 04:13:25', new DateTimeZone('America/New_York')),
-            10
-          ],
-          [
-            new DateTime('2013-03-29 04:13:35', new DateTimeZone('America/New_York')),
-            new DateTime('2013-03-29 04:14:40', new DateTimeZone('America/New_York')),
-            65
-          ],
-          [
-            new DateTime('2013-03-29', new DateTimeZone('America/New_York')),
-            new DateTime('2013-03-29', new DateTimeZone('America/New_York'))
-          ],
-          [
-            new DateTime('2013-03-29 04:13:35', new DateTimeZone('America/New_York')),
-            new DateTime('2013-03-29 03:13:35', new DateTimeZone('America/Chicago'))
-          ],
-          [
-            new DateTime('2013-03-29 04:13:35', new DateTimeZone('America/New_York')),
-            new DateTime('2013-03-29 03:13:49', new DateTimeZone('America/Chicago')),
-            15
-          ],
-          [
-            new DateTime('2013-03-30', new DateTimeZone('America/New_York')),
-            new DateTime('2013-03-29 23:00:00', new DateTimeZone('America/Chicago'))
-          ],
-          [
-            new DateTime('2013-03-30', new DateTimeZone('America/New_York')),
-            new DateTime('2013-03-29 23:01:30', new DateTimeZone('America/Chicago')),
-            100
-          ],
-          [
-            new DateTime('@1364616000'),
-            new DateTime('2013-03-29 23:00:00', new DateTimeZone('America/Chicago'))
-          ],
-          [
-            new DateTime('2013-03-29T05:13:35-0500'),
-            new DateTime('2013-03-29T04:13:35-0600')
-          ]
+            [
+                new DateTime('2013-03-29 04:13:35', new DateTimeZone('America/New_York')),
+                new DateTime('2013-03-29 04:13:25', new DateTimeZone('America/New_York')),
+                10
+            ],
+            [
+                new DateTime('2013-03-29 04:13:35', new DateTimeZone('America/New_York')),
+                new DateTime('2013-03-29 04:14:40', new DateTimeZone('America/New_York')),
+                65
+            ],
+            [
+                new DateTime('2013-03-29', new DateTimeZone('America/New_York')),
+                new DateTime('2013-03-29', new DateTimeZone('America/New_York'))
+            ],
+            [
+                new DateTime('2013-03-29 04:13:35', new DateTimeZone('America/New_York')),
+                new DateTime('2013-03-29 03:13:35', new DateTimeZone('America/Chicago'))
+            ],
+            [
+                new DateTime('2013-03-29 04:13:35', new DateTimeZone('America/New_York')),
+                new DateTime('2013-03-29 03:13:49', new DateTimeZone('America/Chicago')),
+                15
+            ],
+            [
+                new DateTime('2013-03-30', new DateTimeZone('America/New_York')),
+                new DateTime('2013-03-29 23:00:00', new DateTimeZone('America/Chicago'))
+            ],
+            [
+                new DateTime('2013-03-30', new DateTimeZone('America/New_York')),
+                new DateTime('2013-03-29 23:01:30', new DateTimeZone('America/Chicago')),
+                100
+            ],
+            [
+                new DateTime('@1364616000'),
+                new DateTime('2013-03-29 23:00:00', new DateTimeZone('America/Chicago'))
+            ],
+            [
+                new DateTime('2013-03-29T05:13:35-0500'),
+                new DateTime('2013-03-29T04:13:35-0600')
+            ]
         ];
     }
 
     public function assertEqualsFailsProvider()
     {
         return [
-          [
-            new DateTime('2013-03-29 04:13:35', new DateTimeZone('America/New_York')),
-            new DateTime('2013-03-29 03:13:35', new DateTimeZone('America/New_York'))
-          ],
-          [
-            new DateTime('2013-03-29 04:13:35', new DateTimeZone('America/New_York')),
-            new DateTime('2013-03-29 03:13:35', new DateTimeZone('America/New_York')),
-            3500
-          ],
-          [
-            new DateTime('2013-03-29 04:13:35', new DateTimeZone('America/New_York')),
-            new DateTime('2013-03-29 05:13:35', new DateTimeZone('America/New_York')),
-            3500
-          ],
-          [
-            new DateTime('2013-03-29', new DateTimeZone('America/New_York')),
-            new DateTime('2013-03-30', new DateTimeZone('America/New_York'))
-          ],
-          [
-            new DateTime('2013-03-29', new DateTimeZone('America/New_York')),
-            new DateTime('2013-03-30', new DateTimeZone('America/New_York')),
-            43200
-          ],
-          [
-            new DateTime('2013-03-29 04:13:35', new DateTimeZone('America/New_York')),
-            new DateTime('2013-03-29 04:13:35', new DateTimeZone('America/Chicago')),
-          ],
-          [
-            new DateTime('2013-03-29 04:13:35', new DateTimeZone('America/New_York')),
-            new DateTime('2013-03-29 04:13:35', new DateTimeZone('America/Chicago')),
-            3500
-          ],
-          [
-            new DateTime('2013-03-30', new DateTimeZone('America/New_York')),
-            new DateTime('2013-03-30', new DateTimeZone('America/Chicago'))
-          ],
-          [
-            new DateTime('2013-03-29T05:13:35-0600'),
-            new DateTime('2013-03-29T04:13:35-0600')
-          ],
-          [
-            new DateTime('2013-03-29T05:13:35-0600'),
-            new DateTime('2013-03-29T05:13:35-0500')
-          ],
+            [
+                new DateTime('2013-03-29 04:13:35', new DateTimeZone('America/New_York')),
+                new DateTime('2013-03-29 03:13:35', new DateTimeZone('America/New_York'))
+            ],
+            [
+                new DateTime('2013-03-29 04:13:35', new DateTimeZone('America/New_York')),
+                new DateTime('2013-03-29 03:13:35', new DateTimeZone('America/New_York')),
+                3500
+            ],
+            [
+                new DateTime('2013-03-29 04:13:35', new DateTimeZone('America/New_York')),
+                new DateTime('2013-03-29 05:13:35', new DateTimeZone('America/New_York')),
+                3500
+            ],
+            [
+                new DateTime('2013-03-29', new DateTimeZone('America/New_York')),
+                new DateTime('2013-03-30', new DateTimeZone('America/New_York'))
+            ],
+            [
+                new DateTime('2013-03-29', new DateTimeZone('America/New_York')),
+                new DateTime('2013-03-30', new DateTimeZone('America/New_York')),
+                43200
+            ],
+            [
+                new DateTime('2013-03-29 04:13:35', new DateTimeZone('America/New_York')),
+                new DateTime('2013-03-29 04:13:35', new DateTimeZone('America/Chicago')),
+            ],
+            [
+                new DateTime('2013-03-29 04:13:35', new DateTimeZone('America/New_York')),
+                new DateTime('2013-03-29 04:13:35', new DateTimeZone('America/Chicago')),
+                3500
+            ],
+            [
+                new DateTime('2013-03-30', new DateTimeZone('America/New_York')),
+                new DateTime('2013-03-30', new DateTimeZone('America/Chicago'))
+            ],
+            [
+                new DateTime('2013-03-29T05:13:35-0600'),
+                new DateTime('2013-03-29T04:13:35-0600')
+            ],
+            [
+                new DateTime('2013-03-29T05:13:35-0600'),
+                new DateTime('2013-03-29T05:13:35-0500')
+            ],
         ];
     }
 
@@ -150,10 +146,10 @@ class DateTimeComparatorTest extends TestCase
     public function testAcceptsSucceeds()
     {
         $this->assertTrue(
-          $this->comparator->accepts(
-            new DateTime,
-            new DateTime
-          )
+            $this->comparator->accepts(
+                new DateTime,
+                new DateTime
+            )
         );
     }
 
@@ -164,7 +160,7 @@ class DateTimeComparatorTest extends TestCase
     public function testAcceptsFails($expected, $actual)
     {
         $this->assertFalse(
-          $this->comparator->accepts($expected, $actual)
+            $this->comparator->accepts($expected, $actual)
         );
     }
 

--- a/tests/DateTimeComparatorTest.php
+++ b/tests/DateTimeComparatorTest.php
@@ -86,7 +86,12 @@ class DateTimeComparatorTest extends TestCase
             [
                 new DateTime('2013-03-29T05:13:35-0500'),
                 new DateTime('2013-03-29T04:13:35-0600')
-            ]
+            ],
+            [
+                new DateTimeImmutable('2013-03-30', new DateTimeZone('America/New_York')),
+                new DateTimeImmutable('2013-03-29 23:01:30', new DateTimeZone('America/Chicago')),
+                100
+            ],
         ];
     }
 


### PR DESCRIPTION
With the changes made in 408d0d190976d08de44f19a8e502195a423b1281, comparison for `DateTimeImmutable` objects is broken, as the clone is no longer modified but rather returned as the result of the `setTimezone` and `add` calls. This pull requests uses the fluid interface defined for `DateTime` and `DateTimeImmutable` to ensure the modified clones are compared.

While making this change, I discovered indentation issues in the comparator test. If you'd rather not have whitespace fixes along with this pull request, let me know and I'll drop the commit.