### PR TITLE
Fix serialization of ComparisionFailure with PDO in stacktrace.

### DIFF
--- a/src/ComparisonFailure.php
+++ b/src/ComparisonFailure.php
@@ -15,7 +15,7 @@ use SebastianBergmann\Diff\Output\UnifiedDiffOutputBuilder;
 /**
  * Thrown when an assertion for string equality failed.
  */
-class ComparisonFailure extends \RuntimeException
+class ComparisonFailure extends \RuntimeException implements \Serializable
 {
     /**
      * Expected value of the retrieval which does not match $actual.
@@ -124,5 +124,27 @@ class ComparisonFailure extends \RuntimeException
     public function toString()
     {
         return $this->message . $this->getDiff();
+    }
+
+    /**
+     * Serialises all parts of the comparison failure, apart from the stacktrace which might contain references to
+     * objects which cannot be serialised.
+     *
+     * @return string
+     */
+    public function serialize()
+    {
+        return serialize(array(
+            $this->expected, $this->actual, $this->expectedAsString, $this->actualAsString,
+            $this->identical, $this->message, $this->file, $this->line
+        ));
+    }
+
+    public function unserialize($serialized)
+    {
+        list(
+            $this->expected, $this->actual, $this->expectedAsString, $this->actualAsString,
+            $this->identical, $this->message, $this->file, $this->line
+        ) = unserialize($serialized);
     }
 }

--- a/tests/ComparisonFailureTest.php
+++ b/tests/ComparisonFailureTest.php
@@ -56,4 +56,24 @@ final class ComparisonFailureTest extends TestCase
         $this->assertSame('', $failure->getDiff());
         $this->assertSame('test', $failure->toString());
     }
+
+    public function testSerializesWithoutStackTrace()
+    {
+        $instance = new NonSerializableClass;
+
+        $failure = $this->functionWithNonSerializableParam($instance);
+
+        $serialised = serialize($failure);
+        $deserialised = unserialize($serialised);
+
+        $this->assertSame($failure->getActual(), $deserialised->getActual());
+        $this->assertSame($failure->getExpected(), $deserialised->getExpected());
+        $this->assertSame($failure->getActualAsString(), $deserialised->getActualAsString());
+        $this->assertSame($failure->getExpectedAsString(), $deserialised->getExpectedAsString());
+        $this->assertSame($failure->toString(), $deserialised->toString());
+    }
+
+    private function functionWithNonSerializableParam(NonSerializableClass $instance) {
+        return new ComparisonFailure('a', 'b', 'a', 'b', false, 'test');
+    }
 }

--- a/tests/_fixture/NonSerializableClass.php
+++ b/tests/_fixture/NonSerializableClass.php
@@ -1,0 +1,20 @@
+<?php
+/*
+ * This file is part of sebastian/comparator.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SebastianBergmann\Comparator;
+
+class NonSerializableClass implements \Serializable {
+    public function serialize()
+    {
+        throw new \Error('This class cannot be serialized');
+    }
+
+    public function unserialize($serialized) {}
+}


### PR DESCRIPTION
This fix implements a custom serialize/deserialize method on the
ComparisionFailure class, which means it loses the stack trace
during serialization.

This allows PHPUnit to run in process isolation mode when the stack
trace may contain references to non-serializable objects such as
the PDO.