### PR TITLE
Disable escaping of non-latin characters

### DIFF
--- a/src/DOMNodeComparator.php
+++ b/src/DOMNodeComparator.php
@@ -37,7 +37,7 @@ class DOMNodeComparator extends ObjectComparator
      * @param mixed $expected     First value to compare
      * @param mixed $actual       Second value to compare
      * @param float $delta        Allowed numerical distance between two values to consider them equal
-     * @param bool  $canonicalize Arrays are sorted before comparison when set to true
+     * @param bool  $canonicalize The value of this argument ignored and always considered as true
      * @param bool  $ignoreCase   Case is ignored when set to true
      * @param array $processed    List of already processed elements (used to prevent infinite recursion)
      *
@@ -45,8 +45,8 @@ class DOMNodeComparator extends ObjectComparator
      */
     public function assertEquals($expected, $actual, $delta = 0.0, $canonicalize = false, $ignoreCase = false, array &$processed = [])
     {
-        $expectedAsString = $this->nodeToText($expected, true, $ignoreCase);
-        $actualAsString   = $this->nodeToText($actual, true, $ignoreCase);
+        $expectedAsString = $this->nodeToText($expected, $ignoreCase);
+        $actualAsString   = $this->nodeToText($actual, $ignoreCase);
 
         if ($expectedAsString !== $actualAsString) {
             $type = $expected instanceof DOMDocument ? 'documents' : 'nodes';
@@ -65,22 +65,30 @@ class DOMNodeComparator extends ObjectComparator
     /**
      * Returns the normalized, whitespace-cleaned, and indented textual
      * representation of a DOMNode.
+     *
+     * @param  DOMNode $node
+     * @param  bool $ignoreCase If false - xml text will be converted to lowercase
+     *
+     * @return string Text representation of DOMNode
      */
-    private function nodeToText(DOMNode $node, bool $canonicalize, bool $ignoreCase): string
+    public function nodeToText(DOMNode $node, bool $ignoreCase): string
     {
-        if ($canonicalize) {
-            $document = new DOMDocument;
-            @$document->loadXML($node->C14N());
+        $encoding = (isset($node->encoding)) ? $node->encoding : 'UTF-8';
+        $xmlVersion = $node->xmlVersion;
 
-            $node = $document;
+        $document = new DOMDocument($xmlVersion, $encoding);
+        
+        $nodeString = $node->C14N();
+
+        // If an empty string is passed as the source, a warning will be generated.
+        if ($nodeString !== "") {
+            $document->loadXML($nodeString);
+            // $nodeString dows not contain `<?xml` declaration after ->C14N(). So ->encoding become NULL after loadXML.
+            $document->encoding = $encoding;
         }
+        $node = $document;
 
-        $document = $node instanceof DOMDocument ? $node : $node->ownerDocument;
-
-        $document->formatOutput = true;
-        $document->normalizeDocument();
-
-        $text = $node instanceof DOMDocument ? $node->saveXML() : $document->saveXML($node);
+        $text = $node->saveXML();
 
         return $ignoreCase ? $text : \strtolower($text);
     }

--- a/tests/DOMNodeComparatorTest.php
+++ b/tests/DOMNodeComparatorTest.php
@@ -77,6 +77,14 @@ class DOMNodeComparatorTest extends TestCase
             $this->createDOMDocument("<a x='' a=''/>"),
             $this->createDOMDocument("<a a='' x=''/>"),
           ],
+          [
+            $this->createDOMDocument('<?xml version="1.0"?><foo>тест</foo>'),
+            $this->createDOMDocument('<?xml version="1.0"?><foo>&#x442;&#x435;&#x441;&#x442;</foo>'),
+          ],
+          [
+            $this->createDOMDocument('<?xml version="1.0"?><foo>тест</foo>'),
+            $this->createDOMDocument('<?xml version="1.0" encoding="UTF-8"?><foo>тест</foo>'),
+          ],
         ];
     }
 
@@ -102,7 +110,15 @@ class DOMNodeComparatorTest extends TestCase
           [
             $this->createDOMDocument('<foo> bar </foo>'),
             $this->createDOMDocument('<foo> bir </foo>')
-          ]
+          ],
+          [
+            $this->createDOMDocument('<?xml version="1.0" encoding="UTF-8"?><foo>test</foo>'),
+            $this->createDOMDocument('<?xml version="1.0" encoding="CP1251"?><foo>test</foo>'),
+          ],
+          [
+            $this->createDOMDocument('<?xml version="1.0"?><foo>test</foo>'),
+            $this->createDOMDocument('<?xml version="1.0" encoding="CP1251"?><foo>test</foo>'),
+          ],
         ];
     }
 
@@ -166,6 +182,17 @@ class DOMNodeComparatorTest extends TestCase
         $this->expectExceptionMessage('Failed asserting that two DOM');
 
         $this->comparator->assertEquals($expected, $actual);
+    }
+
+    /**
+     * Ensures that non-latin text is not escaped
+     */
+    public function testNodeToTextNotEscaped() {
+      $xml = "<root>тест</root>";
+      $expected = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<root>тест</root>\n";
+      $document = $this->createDOMDocument($xml);
+
+      $this->assertSame($expected, $this->comparator->nodeToText($document, true));
     }
 
     private function createDOMDocument($content)

--- a/tests/DOMNodeComparatorTest.php
+++ b/tests/DOMNodeComparatorTest.php
@@ -73,6 +73,10 @@ class DOMNodeComparatorTest extends TestCase
             $this->createDOMDocument("<root>\n  <child/>\n</root>"),
             $this->createDOMDocument('<root><child/></root>')
           ],
+          [
+            $this->createDOMDocument("<a x='' a=''/>"),
+            $this->createDOMDocument("<a a='' x=''/>"),
+          ],
         ];
     }
 


### PR DESCRIPTION
This PR mainly solves #21.

I want to point to a few aspects of my changes:

1. As you can see, I removed
```
$document->formatOutput = true;
$document->normalizeDocument();
```
Because tests not failed and I don't see why it needed. I could return it add appropriate tests if you explain me reason of this code.
2. I removed a lot of checks `instanceof DOMDocument` because in fact there is always DOMDocument in the $node in case if canonicalize is always true.
3. I removed $canonicalize because in fact it is always true and the unused argument just make the code maintenance harder. Especially without corresponding unit-tests.
4. I made nodeToText public to be able to test it.
5. I see the possible error with the $ignoreCase argument (it ignores case when set to false) and I could fix it in this PR or in the different. What do you think?

I'll be happy to receive any criticism/suggestions about the appearance of my changes and tests.