### PR TITLE
Fix "ignore case" in `DOMNodeComparator`

### DIFF
--- a/src/DOMNodeComparator.php
+++ b/src/DOMNodeComparator.php
@@ -82,6 +82,6 @@ class DOMNodeComparator extends ObjectComparator
 
         $text = $node instanceof DOMDocument ? $node->saveXML() : $document->saveXML($node);
 
-        return $ignoreCase ? $text : \strtolower($text);
+        return $ignoreCase ? \strtolower($text) : $text;
     }
 }

--- a/tests/DOMNodeComparatorTest.php
+++ b/tests/DOMNodeComparatorTest.php
@@ -73,6 +73,11 @@ class DOMNodeComparatorTest extends TestCase
             $this->createDOMDocument("<root>\n  <child/>\n</root>"),
             $this->createDOMDocument('<root><child/></root>')
           ],
+          [
+            $this->createDOMDocument('<Root></Root>'),
+            $this->createDOMDocument('<root></root>'),
+            $ignoreCase = true
+          ]
         ];
     }
 
@@ -98,6 +103,14 @@ class DOMNodeComparatorTest extends TestCase
           [
             $this->createDOMDocument('<foo> bar </foo>'),
             $this->createDOMDocument('<foo> bir </foo>')
+          ],
+          [
+            $this->createDOMDocument('<Root></Root>'),
+            $this->createDOMDocument('<root></root>')
+          ],
+          [
+            $this->createDOMDocument('<root> bar </root>'),
+            $this->createDOMDocument('<root> BAR </root>')
           ]
         ];
     }
@@ -136,13 +149,16 @@ class DOMNodeComparatorTest extends TestCase
      *
      * @param mixed $expected
      * @param mixed $actual
+     * @param bool  $ignoreCase
      */
-    public function testAssertEqualsSucceeds($expected, $actual)
+    public function testAssertEqualsSucceeds($expected, $actual, $ignoreCase = false)
     {
         $exception = null;
 
         try {
-            $this->comparator->assertEquals($expected, $actual);
+            $delta = 0.0;
+            $canonicalize = false;
+            $this->comparator->assertEquals($expected, $actual, $delta, $canonicalize, $ignoreCase);
         } catch (ComparisonFailure $exception) {
         }
 


### PR DESCRIPTION
The logic of `$ignoreCase` was inverted by mistake in `DOMNodeComparator`.

This made PHPUnit's `assertXml*EqualsXml*()` case-insensitive by default.