### PR TITLE
Added unit-test that ensures xml arguments order doesn't matter

### DIFF
--- a/tests/DOMNodeComparatorTest.php
+++ b/tests/DOMNodeComparatorTest.php
@@ -77,7 +77,11 @@ class DOMNodeComparatorTest extends TestCase
             $this->createDOMDocument('<Root></Root>'),
             $this->createDOMDocument('<root></root>'),
             $ignoreCase = true
-          ]
+          ],
+          [
+            $this->createDOMDocument("<a x='' a=''/>"),
+            $this->createDOMDocument("<a a='' x=''/>"),
+          ],
         ];
     }
 


### PR DESCRIPTION
This test was suggested in https://github.com/sebastianbergmann/phpunit/pull/1236#issue-15314688, but wasn't be implemented.