### PR TITLE
Prove that ScalarComparator doesn't follow ==

### DIFF
--- a/tests/ScalarComparatorTest.php
+++ b/tests/ScalarComparatorTest.php
@@ -141,6 +141,12 @@ final class ScalarComparatorTest extends TestCase
      */
     public function testAssertEqualsSucceeds($expected, $actual, $ignoreCase = false): void
     {
+        if ($ignoreCase) {
+            $this->assertTrue(strtolower($expected) == strtolower($actual));
+        } else {
+            $this->assertTrue($expected == $actual);
+        }
+
         $exception = null;
 
         try {
@@ -156,6 +162,8 @@ final class ScalarComparatorTest extends TestCase
      */
     public function testAssertEqualsFails($expected, $actual, $message): void
     {
+        $this->assertTrue($expected != $actual);
+
         $this->expectException(ComparisonFailure::class);
         $this->expectExceptionMessage($message);
 


### PR DESCRIPTION
According to docs of `ScalarComparator`:
> Compares scalar or NULL values for equality.

`equality`, do we consider it as an equality operator `==` of PHP ?

for that, I would propose to put extra assertion that compares not only if `expected/actual` matches provided expectation, but also are they following contract and mimics `==` equality.

I expect Travis to fail and show when contract of `==` is violated

ref: https://github.com/sebastianbergmann/phpunit/issues/3185
ref: https://github.com/sebastianbergmann/comparator/pull/58/files