### PR TITLE
Comparison of DateTime and DateTimeImmutable mock objects

### DIFF
--- a/src/DateTimeComparator.php
+++ b/src/DateTimeComparator.php
@@ -43,6 +43,10 @@ class DateTimeComparator extends ObjectComparator
      */
     public function assertEquals($expected, $actual, $delta = 0.0, $canonicalize = false, $ignoreCase = false, array &$processed = [])
     {
+        if (\spl_object_hash($expected) === \spl_object_hash($actual)) {
+            return;
+        }
+
         /** @var \DateTimeInterface $expected */
         /** @var \DateTimeInterface $actual */
         $absDelta = \abs($delta);

--- a/tests/DateTimeComparatorTest.php
+++ b/tests/DateTimeComparatorTest.php
@@ -11,6 +11,7 @@ namespace SebastianBergmann\Comparator;
 
 use DateTime;
 use DateTimeImmutable;
+use DateTimeInterface;
 use DateTimeZone;
 use PHPUnit\Framework\TestCase;
 
@@ -194,6 +195,44 @@ final class DateTimeComparatorTest extends TestCase
         $this->expectExceptionMessage('Failed asserting that two DateTime objects are equal.');
 
         $this->comparator->assertEquals($expected, $actual, $delta);
+    }
+
+    public function testSameDateTimeImmutableInstancesShouldNotTriggerAnyMethods(): void
+    {
+        $dateTimeImmutableMock = $this->createMock(DateTimeImmutable::class);
+        $methods = \get_class_methods(DateTimeImmutable::class);
+
+        foreach ($methods as $method) {
+            if ($method === '__construct') {
+                continue;
+            }
+
+            $dateTimeImmutableMock
+                ->expects($this->never())
+                ->method($method)
+            ;
+        }
+
+        $this->comparator->assertEquals($dateTimeImmutableMock, $dateTimeImmutableMock);
+    }
+
+    public function testSameDateTimeInstancesShouldNotTriggerAnyMethods(): void
+    {
+        $dateTimeMock = $this->createMock(DateTime::class);
+        $methods = \get_class_methods(DateTime::class);
+
+        foreach ($methods as $method) {
+            if ($method === '__construct') {
+                continue;
+            }
+
+            $dateTimeMock
+                ->expects($this->never())
+                ->method($method)
+            ;
+        }
+
+        $this->comparator->assertEquals($dateTimeMock, $dateTimeMock);
     }
 
     public function testAcceptsDateTimeInterface(): void


### PR DESCRIPTION
Fixes:
- https://github.com/sebastianbergmann/phpunit/issues/3208
- https://github.com/phpspec/phpspec/issues/887

Problem:

In certain scenarios mocking DateTime and DateTimeImmutable instances might be required. Currently any comparison between such mocks will fail because some methods are invoked by the comparator and it comes as a surprise to everyone involved.

Solution:

We might mock the methods, however, even if we expect the methods to be called in the mocks, there's no guarantee the implementation won't change in the next version of the library.

In most cases if we are mocking an object, we would probably be comparing it to the very same instance later on in the unit test. I figured, we could use `spl_object_hash()` to validate whether the actual and the expected values reference the same instance and skip comparing any other properties if so.

I wrote a unit test to validate that mocks of both `DateTime` and `DateTimeImmutable` pass. I am willing to write one that asserts that a clone of a mock would fail, but am not sure how to catch the error shown.

Do you think there are drawbacks to this approach? Let me know what your thoughts are.