### PR TITLE
Avoid converting an object to an array when checking equality

### DIFF
--- a/src/MockObjectComparator.php
+++ b/src/MockObjectComparator.php
@@ -27,21 +27,4 @@ class MockObjectComparator extends ObjectComparator
         return ($expected instanceof \PHPUnit_Framework_MockObject_MockObject || $expected instanceof \PHPUnit\Framework\MockObject\MockObject) &&
                ($actual instanceof \PHPUnit_Framework_MockObject_MockObject || $actual instanceof \PHPUnit\Framework\MockObject\MockObject);
     }
-
-    /**
-     * Converts an object to an array containing all of its private, protected
-     * and public properties.
-     *
-     * @param object $object
-     *
-     * @return array
-     */
-    protected function toArray($object)
-    {
-        $array = parent::toArray($object);
-
-        unset($array['__phpunit_invocationMocker']);
-
-        return $array;
-    }
 }

--- a/src/ObjectComparator.php
+++ b/src/ObjectComparator.php
@@ -12,7 +12,7 @@ namespace SebastianBergmann\Comparator;
 /**
  * Compares objects for equality.
  */
-class ObjectComparator extends ArrayComparator
+class ObjectComparator
 {
     /**
      * Returns whether the comparator can compare two values.
@@ -28,7 +28,7 @@ class ObjectComparator extends ArrayComparator
     }
 
     /**
-     * Asserts that two values are equal.
+     * Asserts that two objects are equal.
      *
      * @param mixed $expected     First value to compare
      * @param mixed $actual       Second value to compare
@@ -64,43 +64,15 @@ class ObjectComparator extends ArrayComparator
 
         $processed[] = [$actual, $expected];
 
-        // don't compare objects if they are identical
-        // this helps to avoid the error "maximum function nesting level reached"
-        // CAUTION: this conditional clause is not tested
-        if ($actual !== $expected) {
-            try {
-                parent::assertEquals(
-                    $this->toArray($expected),
-                    $this->toArray($actual),
-                    $delta,
-                    $canonicalize,
-                    $ignoreCase,
-                    $processed
-                );
-            } catch (ComparisonFailure $e) {
-                throw new ComparisonFailure(
-                    $expected,
-                    $actual,
-                    // replace "Array" with "MyClass object"
-                    \substr_replace($e->getExpectedAsString(), \get_class($expected) . ' Object', 0, 5),
-                    \substr_replace($e->getActualAsString(), \get_class($actual) . ' Object', 0, 5),
-                    false,
-                    'Failed asserting that two objects are equal.'
-                );
-            }
+        if ($actual != $expected) {
+            throw new ComparisonFailure(
+                $expected,
+                $actual,
+                \get_class($expected) . ' Object',
+                \get_class($actual) . ' Object',
+                false,
+                'Failed asserting that two objects are equal.'
+            );
         }
-    }
-
-    /**
-     * Converts an object to an array containing all of its private, protected
-     * and public properties.
-     *
-     * @param object $object
-     *
-     * @return array
-     */
-    protected function toArray($object)
-    {
-        return $this->exporter->toArray($object);
     }
 }

--- a/src/ObjectComparator.php
+++ b/src/ObjectComparator.php
@@ -41,6 +41,10 @@ class ObjectComparator extends Comparator
      */
     public function assertEquals($expected, $actual, $delta = 0.0, $canonicalize = false, $ignoreCase = false, array &$processed = [])
     {
+        if ($expected === $actual) {
+            return;
+        }
+        
         if (\get_class($actual) !== \get_class($expected)) {
             throw new ComparisonFailure(
                 $expected,

--- a/src/ObjectComparator.php
+++ b/src/ObjectComparator.php
@@ -12,7 +12,7 @@ namespace SebastianBergmann\Comparator;
 /**
  * Compares objects for equality.
  */
-class ObjectComparator
+class ObjectComparator extends Comparator
 {
     /**
      * Returns whether the comparator can compare two values.

--- a/src/ObjectComparator.php
+++ b/src/ObjectComparator.php
@@ -35,11 +35,10 @@ class ObjectComparator extends Comparator
      * @param float $delta        Allowed numerical distance between two values to consider them equal
      * @param bool  $canonicalize Arrays are sorted before comparison when set to true
      * @param bool  $ignoreCase   Case is ignored when set to true
-     * @param array $processed    List of already processed elements (used to prevent infinite recursion)
      *
      * @throws ComparisonFailure
      */
-    public function assertEquals($expected, $actual, $delta = 0.0, $canonicalize = false, $ignoreCase = false, array &$processed = [])
+    public function assertEquals($expected, $actual, $delta = 0.0, $canonicalize = false, $ignoreCase = false)
     {
         // assume that identity implies equality
         if ($expected === $actual) {
@@ -60,14 +59,6 @@ class ObjectComparator extends Comparator
                 )
             );
         }
-
-        // don't compare twice to allow for cyclic dependencies
-        if (\in_array([$actual, $expected], $processed) ||
-            \in_array([$expected, $actual], $processed)) {
-            return;
-        }
-
-        $processed[] = [$actual, $expected];
 
         if ($actual != $expected) {
             throw new ComparisonFailure(

--- a/src/ObjectComparator.php
+++ b/src/ObjectComparator.php
@@ -41,6 +41,7 @@ class ObjectComparator extends Comparator
      */
     public function assertEquals($expected, $actual, $delta = 0.0, $canonicalize = false, $ignoreCase = false, array &$processed = [])
     {
+        // assume that identity implies equality
         if ($expected === $actual) {
             return;
         }
@@ -61,8 +62,8 @@ class ObjectComparator extends Comparator
         }
 
         // don't compare twice to allow for cyclic dependencies
-        if (\in_array([$actual, $expected], $processed, true) ||
-            \in_array([$expected, $actual], $processed, true)) {
+        if (\in_array([$actual, $expected], $processed) ||
+            \in_array([$expected, $actual], $processed)) {
             return;
         }
 


### PR DESCRIPTION
This has come up where `assertEquals` fails for internal objects that override comparison using the `compare` or `compare_objects` handlers. Internally, PHP compares object properties when using `==`, which is effectively what the array cast was doing.

This change allows for objects that override equality to work as expected with `assertEquals`. 

It's also worth mentioning that a future Comparable interface would most likely override the behaviour of `==` and is therefore also some future-proofing here.