### PR TITLE
Fix typo in test variable name

### DIFF
--- a/tests/MockObjectComparatorTest.php
+++ b/tests/MockObjectComparatorTest.php
@@ -137,7 +137,7 @@ final class MockObjectComparatorTest extends TestCase
         $book1->author          = $this->getMockBuilder(Author::class)->setMethods(null)->setConstructorArgs(['Terry Pratchett'])->getMock();
         $book1->author->books[] = $book1;
         $book2                  = $this->getMockBuilder(Book::class)->setMethods(null)->getMock();
-        $book1->author          = $this->getMockBuilder(Author::class)->setMethods(null)->setConstructorArgs(['Terry Pratch'])->getMock();
+        $book2->author          = $this->getMockBuilder(Author::class)->setMethods(null)->setConstructorArgs(['Terry Pratch'])->getMock();
         $book2->author->books[] = $book2;
 
         $book3         = $this->getMockBuilder(Book::class)->setMethods(null)->getMock();


### PR DESCRIPTION
book1->author is initialized twice, and book2->author not at all,
resulting in this warning:

  PHP Warning:  Creating default object from empty value in /usr/local/src/comparator/tests/MockObjectComparatorTest.php on line 95

Fixes issue #80