### PR TITLE
When C14N fails try comparison without canonicalization

### DIFF
--- a/src/DOMNodeComparator.php
+++ b/src/DOMNodeComparator.php
@@ -78,7 +78,7 @@ class DOMNodeComparator extends ObjectComparator
             }
 
             $document = new DOMDocument;
-            @$document->loadXML($c14n);
+            $document->loadXML($c14n);
 
             $node = $document;
         }

--- a/src/DOMNodeComparator.php
+++ b/src/DOMNodeComparator.php
@@ -73,8 +73,8 @@ class DOMNodeComparator extends ObjectComparator
             /** @psalm-var string|false $c14n */
             $c14n = @$node->C14N();
 
-            if ($c14n === false) { // try node-to-text without canonicalize
-                return $this->nodeToText($node, !$canonicalize, $ignoreCase);
+            if ($c14n === false || $c14n === '') { // try node-to-text without canonicalize
+                return $this->nodeToText($node, false, $ignoreCase);
             }
 
             $document = new DOMDocument;

--- a/src/DOMNodeComparator.php
+++ b/src/DOMNodeComparator.php
@@ -70,8 +70,15 @@ class DOMNodeComparator extends ObjectComparator
     private function nodeToText(DOMNode $node, bool $canonicalize, bool $ignoreCase): string
     {
         if ($canonicalize) {
+            /** @psalm-var string|false $c14n */
+            $c14n = @$node->C14N();
+
+            if ($c14n === false) { // try node-to-text without canonicalize
+                return $this->nodeToText($node, !$canonicalize, $ignoreCase);
+            }
+
             $document = new DOMDocument;
-            @$document->loadXML($node->C14N());
+            @$document->loadXML($c14n);
 
             $node = $document;
         }

--- a/tests/DOMNodeComparatorTest.php
+++ b/tests/DOMNodeComparatorTest.php
@@ -84,14 +84,6 @@ final class DOMNodeComparatorTest extends TestCase
                 $this->createDOMDocument("<a x='' a=''/>"),
                 $this->createDOMDocument("<a a='' x=''/>"),
             ],
-            [
-                $this->createDOMDocument(
-                    '<!DOCTYPE foo SYSTEM "foo.dtd" [<!ENTITY ns_foo "http://uri.tld/foo">]><i:foo xmlns:i="&ns_foo;"/>'
-                ),
-                $this->createDOMDocument(
-                    '<!DOCTYPE foo SYSTEM "foo.dtd" [<!ENTITY ns_foo "http://uri.tld/foo">]><i:foo xmlns:i="&ns_foo;"/>'
-                ),
-            ],
         ];
     }
 
@@ -126,15 +118,50 @@ final class DOMNodeComparatorTest extends TestCase
                 $this->createDOMDocument('<root> bar </root>'),
                 $this->createDOMDocument('<root> BAR </root>'),
             ],
+        ];
+    }
+
+    public function assertEqualsSucceedsWithNonCanonicalizableNodesProvider()
+    {
+        $document = new DOMDocument;
+
+        return [
+            [$document, new DOMDocument],
+            [$document->createElement('foo'), $document->createElement('foo')],
             [
                 $this->createDOMDocument(
                     '<!DOCTYPE foo SYSTEM "foo.dtd" [<!ENTITY ns_foo "http://uri.tld/foo">]><i:foo xmlns:i="&ns_foo;"/>'
                 ),
                 $this->createDOMDocument(
-                    '<!DOCTYPE foo SYSTEM "foo.dtd" [<!ENTITY ns_foo "http://uri.tld/foo">]>' .
-                    '<i:foo xmlns:i="&ns_foo;" bar="I am different"/>'
+                    '<!DOCTYPE foo SYSTEM "foo.dtd" [<!ENTITY ns_foo "http://uri.tld/foo">]><i:foo xmlns:i="&ns_foo;"/>'
                 ),
             ],
+        ];
+    }
+
+    public function assertEqualsFailsWithNonCanonicalizableNodesProvider()
+    {
+        // empty document makes C14N return empty string
+        $document = new DOMDocument;
+
+        // nodes created but not appended to the document makes C14N return empty string
+        $nodeFoo = $document->createElement('foo');
+        $nodeBar = $document->createElement('bar');
+
+        // documents with xmlns definitions to xml entities makes C14N return false
+        $documentNsUriIsEntityFoo = $this->createDOMDocument( // root element is i:foo
+            '<!DOCTYPE foo SYSTEM "foo.dtd" [<!ENTITY ns_foo "http://uri.tld/foo">]><i:foo xmlns:i="&ns_foo;"/>'
+        );
+        $documentNsUriIsEntityBar = $this->createDOMDocument( // root element is i:bar
+            '<!DOCTYPE foo SYSTEM "foo.dtd" [<!ENTITY ns_foo "http://uri.tld/foo">]><i:bar xmlns:i="&ns_foo;"/>'
+        );
+
+        return [
+            [$document, $nodeFoo],
+            [$document, $documentNsUriIsEntityFoo],
+            [$nodeFoo, $nodeBar],
+            [$nodeFoo, $documentNsUriIsEntityFoo],
+            [$documentNsUriIsEntityFoo, $documentNsUriIsEntityBar],
         ];
     }
 
@@ -184,6 +211,22 @@ final class DOMNodeComparatorTest extends TestCase
         $this->expectExceptionMessage('Failed asserting that two DOM');
 
         $this->comparator->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @dataProvider assertEqualsSucceedsWithNonCanonicalizableNodesProvider
+     */
+    public function testAssertEqualsSucceedsWithNonCanonicalizableNodes($expected, $actual): void
+    {
+        $this->testAssertEqualsSucceeds($expected, $actual);
+    }
+
+    /**
+     * @dataProvider assertEqualsFailsWithNonCanonicalizableNodesProvider
+     */
+    public function testAssertEqualsFailsWithNonCanonicalizableNodes($expected, $actual): void
+    {
+        $this->testAssertEqualsFails($expected, $actual);
     }
 
     private function createDOMDocument($content)

--- a/tests/DOMNodeComparatorTest.php
+++ b/tests/DOMNodeComparatorTest.php
@@ -84,6 +84,14 @@ final class DOMNodeComparatorTest extends TestCase
                 $this->createDOMDocument("<a x='' a=''/>"),
                 $this->createDOMDocument("<a a='' x=''/>"),
             ],
+            [
+                $this->createDOMDocument(
+                    '<!DOCTYPE foo SYSTEM "foo.dtd" [<!ENTITY ns_foo "http://uri.tld/foo">]><i:foo xmlns:i="&ns_foo;"/>'
+                ),
+                $this->createDOMDocument(
+                    '<!DOCTYPE foo SYSTEM "foo.dtd" [<!ENTITY ns_foo "http://uri.tld/foo">]><i:foo xmlns:i="&ns_foo;"/>'
+                ),
+            ],
         ];
     }
 
@@ -117,6 +125,15 @@ final class DOMNodeComparatorTest extends TestCase
             [
                 $this->createDOMDocument('<root> bar </root>'),
                 $this->createDOMDocument('<root> BAR </root>'),
+            ],
+            [
+                $this->createDOMDocument(
+                    '<!DOCTYPE foo SYSTEM "foo.dtd" [<!ENTITY ns_foo "http://uri.tld/foo">]><i:foo xmlns:i="&ns_foo;"/>'
+                ),
+                $this->createDOMDocument(
+                    '<!DOCTYPE foo SYSTEM "foo.dtd" [<!ENTITY ns_foo "http://uri.tld/foo">]>' .
+                    '<i:foo xmlns:i="&ns_foo;" bar="I am different"/>'
+                ),
             ],
         ];
     }


### PR DESCRIPTION
The issue #87 points out that in some edge cases the C14N can fail.
It is not a common case, even psalm don't recognize that `c14n()` can return `false`.

This problem can be reproduced by setting a namespace uri value as a defined xml entity.

```xml
<!DOCTYPE foo SYSTEM "foo.dtd" [
  <!ENTITY ns_foo "http://uri.tld/foo">
]>
<i:foo xmlns:i="&ns_foo;"/>
```

I append two cases to tests when C14N fails (using current providers):

- Identicals documents must assert equal
- Different documents must throw ComparisonFailure

To solve it, I separate `@$document->loadXML($node->C14N())` into two steps: `$c14n = @$node->C14N()` and `@$document->loadXML($c14n)`.
If `$c14n === false` then retry *node to text conversion* but without using canonicalization.

Observations:

- This is an edge case, C14N failing is very uncommon.
- `DOMNodeComparator::nodeToText` is always called with `$canonicalize = true`, `DOMNodeComparator::assertEquals` ignored the `$canonicalize` argument.
- The comparison on this cases (when C14N fails) is more strict, since canonicalization is not performed.
- Didn't remove the silent operator, and extended it to `c14n()` call. This is preserving the same behavior as before.

If you think is necessary I can try other approaches:

- Node canonicalization and xml loading capturing libxml errors, then throw an exception.
  This will require to add another exception that contains the `libxml_get_errors()` array, or,
  implode the errors into a single message and use the current `SebastianBergmann\Comparator\RuntimException`.

- If convert the node to text fails then throw a `ComparisonFailure`. This is like saying that `$expected` is different than `$actual` because the comparator is unable to perform the comparison.

- Change `DOMNodeComparator::acept()` and only return true if objects are `DOMNode` *and* the canonicalization don't fail. I don't like this approach because canonicalization can be very expensive.
