### PR TITLE
PHP8 compatibility

### DIFF
--- a/src/DOMNodeComparator.php
+++ b/src/DOMNodeComparator.php
@@ -13,6 +13,7 @@ use function sprintf;
 use function strtolower;
 use DOMDocument;
 use DOMNode;
+use ValueError;
 
 /**
  * Compares DOMNode instances for equality.
@@ -71,7 +72,11 @@ class DOMNodeComparator extends ObjectComparator
     {
         if ($canonicalize) {
             $document = new DOMDocument;
-            @$document->loadXML($node->C14N());
+
+            try {
+                @$document->loadXML($node->C14N());
+            } catch (ValueError $e) {
+            }
 
             $node = $document;
         }


### PR DESCRIPTION
What was previously silenced, now becomes: `ValueError: DOMDocument::loadXML(): Argument #1 ($source) must not be empty`

E.g.
```
/.../tests/end-to-end/regression/GitHub/4407.phpt
Failed asserting that string matches format description.
--- Expected
+++ Actual
@@ @@
 PHPUnit 9.4-g6099c5e by Sebastian Bergmann and contributors.
 
-F                                                                   1 / 1 (100%)
+E                                                                   1 / 1 (100%)
 
 Time: 00:00.027, Memory: 6.00 MB
 
-There was 1 failure:
+There was 1 error:
 
 1) Issue4407Test::testOne
-Failed asserting that two DOM documents are equal.
---- Expected
-+++ Actual
-@@ @@
- <?xml version="1.0"?>
--<root>
--  <child>text</child>
--</root>
+ValueError: DOMDocument::loadXML(): Argument #1 ($source) must not be empty
 
-%sIssue4407Test.php:%d
+/.../tests/end-to-end/regression/GitHub/4407/Issue4407Test.php:18
 
-FAILURES!
-Tests: 1, Assertions: 1, Failures: 1.
+ERRORS!
+Tests: 1, Assertions: 1, Errors: 1.

/.../tests/end-to-end/regression/GitHub/4407.phpt:14
/.../src/Framework/TestSuite.php:669
/.../src/Framework/TestSuite.php:669
/.../src/TextUI/TestRunner.php:673
/.../src/TextUI/Command.php:148
/.../src/TextUI/Command.php:101
```