### PR TITLE
Fix: Use PHP 7.3 to run php-cs-fixer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         uses: "actions/checkout@v2"
 
       - name: "Run friendsofphp/php-cs-fixer"
-        run: "./tools/php-cs-fixer fix --diff-format=udiff --dry-run --show-progress=dots --using-cache=no --verbose"
+        run: "php7.3 ./tools/php-cs-fixer fix --diff-format=udiff --dry-run --show-progress=dots --using-cache=no --verbose"
 
   type-checker:
     name: "Type Checker"


### PR DESCRIPTION
This PR

* [x] uses PHP 7.3 (the minimum supported version of PHP for this project) to run `php-cs-fixer`