### PR TITLE
Fix: Run friendsofphp/php-cs-fixer on lowest supported PHP version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,19 @@ jobs:
 
     runs-on: "ubuntu-latest"
 
+    strategy:
+      matrix:
+        php-version:
+          - "7.3"
+
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v2"
+
+      - name: "Set up PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          php-version: "${{ matrix.php-version }}"
 
       - name: "Run friendsofphp/php-cs-fixer"
         run: "./tools/php-cs-fixer fix --diff-format=udiff --dry-run --show-progress=dots --using-cache=no --verbose"


### PR DESCRIPTION
This pull request

* [x] runs `friendsofphp/php-cs-fixer` on the lowest supported PHP version