### PR TITLE
Issue #77: Canonicalizing associative arrays is now done by using ksort instead of sort

### DIFF
--- a/src/ArrayComparator.php
+++ b/src/ArrayComparator.php
@@ -53,7 +53,7 @@ class ArrayComparator extends Comparator
     public function assertEquals($expected, $actual, $delta = 0.0, $canonicalize = false, $ignoreCase = false, array &$processed = [])/*: void*/
     {
         if ($canonicalize) {
-            // If the expected array has non-integer keys, treat arrays as being associative.
+            // If the expected array has non-integer keys, treat arrays as being associative
             $nonIntegerKeysCount = count(array_filter(array_keys($expected), 'is_string'));
 
             if ($nonIntegerKeysCount > 0) {

--- a/src/ArrayComparator.php
+++ b/src/ArrayComparator.php
@@ -53,8 +53,16 @@ class ArrayComparator extends Comparator
     public function assertEquals($expected, $actual, $delta = 0.0, $canonicalize = false, $ignoreCase = false, array &$processed = [])/*: void*/
     {
         if ($canonicalize) {
-            sort($expected);
-            sort($actual);
+            // If the expected array has non-integer keys, treat arrays as being associative.
+            $nonIntegerKeysCount = count(array_filter(array_keys($expected), 'is_string'));
+
+            if ($nonIntegerKeysCount > 0) {
+                ksort($expected);
+                ksort($actual);
+            } else {
+                sort($expected);
+                sort($actual);
+            }
         }
 
         $remaining        = $actual;

--- a/tests/ArrayComparatorTest.php
+++ b/tests/ArrayComparatorTest.php
@@ -158,4 +158,25 @@ final class ArrayComparatorTest extends TestCase
 
         $this->comparator->assertEquals($expected, $actual, $delta, $canonicalize);
     }
+
+    public function testCanonicalizingAssociativeArrays(): void
+    {
+        $expected = [
+            'a' => 1,
+            'b' => 2,
+        ];
+        $actual = [
+            'b' => 2,
+            'a' => 1,
+        ];
+
+        $exception = null;
+
+        try {
+            $this->comparator->assertEquals($expected, $actual, $delta = 0.0, $canonicalize = true);
+        } catch (ComparisonFailure $exception) {
+        }
+
+        $this->assertNull($exception, 'Unexpected ComparisonFailure');
+    }
 }


### PR DESCRIPTION
This covers issue #77 which is also the cause for PHPUnit Issues [#4455](https://github.com/sebastianbergmann/phpunit/issues/4455).

The first change is in "src/ArrayComparator.php" where we first detect if the expected array has any non-integer keys. If that is the case, we treat both arrays as associative and sort them with ksort() instead of sort().

The second change is test coverage of the above logic in "tests/ArrayComparatorTest.php".