### PR TITLE
Support multidimensional and associative arrays when canonicalize

### DIFF
--- a/src/ArrayComparator.php
+++ b/src/ArrayComparator.php
@@ -12,6 +12,7 @@ namespace SebastianBergmann\Comparator;
 use function array_key_exists;
 use function assert;
 use function is_array;
+use function ksort;
 use function sort;
 use function sprintf;
 use function str_replace;
@@ -39,8 +40,8 @@ class ArrayComparator extends Comparator
         assert(is_array($actual));
 
         if ($canonicalize) {
-            sort($expected);
-            sort($actual);
+            $this->canonicalize($expected);
+            $this->canonicalize($actual);
         }
 
         $remaining        = $actual;
@@ -123,5 +124,34 @@ class ArrayComparator extends Comparator
     private function indent(string $lines): string
     {
         return trim(str_replace("\n", "\n    ", $lines));
+    }
+
+    private function canonicalize(array &$array): void
+    {
+        if ($this->isIndexedArray($array)) {
+            sort($array);
+        } else {
+            ksort($array);
+        }
+
+        foreach ($array as &$element) {
+            if (is_array($element)) {
+                $this->canonicalize($element);
+            }
+        }
+    }
+
+    private function isIndexedArray(array $array): bool
+    {
+        $expectedKey = 0;
+
+        foreach ($array as $key => $value) {
+            if ($key !== $expectedKey) {
+                return false;
+            }
+            $expectedKey++;
+        }
+
+        return true;
     }
 }

--- a/src/ArrayComparator.php
+++ b/src/ArrayComparator.php
@@ -9,6 +9,7 @@
  */
 namespace SebastianBergmann\Comparator;
 
+use function array_is_list;
 use function array_key_exists;
 use function assert;
 use function is_array;
@@ -128,7 +129,7 @@ class ArrayComparator extends Comparator
 
     private function canonicalize(array &$array): void
     {
-        if ($this->isIndexedArray($array)) {
+        if (array_is_list($array)) {
             sort($array);
         } else {
             ksort($array);
@@ -139,19 +140,5 @@ class ArrayComparator extends Comparator
                 $this->canonicalize($element);
             }
         }
-    }
-
-    private function isIndexedArray(array $array): bool
-    {
-        $expectedKey = 0;
-
-        foreach ($array as $key => $value) {
-            if ($key !== $expectedKey) {
-                return false;
-            }
-            $expectedKey++;
-        }
-
-        return true;
     }
 }

--- a/src/ArrayComparator.php
+++ b/src/ArrayComparator.php
@@ -134,11 +134,5 @@ class ArrayComparator extends Comparator
         } else {
             ksort($array);
         }
-
-        foreach ($array as &$element) {
-            if (is_array($element)) {
-                $this->canonicalize($element);
-            }
-        }
     }
 }

--- a/tests/ArrayComparatorTest.php
+++ b/tests/ArrayComparatorTest.php
@@ -71,8 +71,8 @@ final class ArrayComparatorTest extends TestCase
                 [true],
             ],
             [
-                ['a', 'b' => [1, 2]],
-                ['b' => [2, 1], 'a'],
+                ['a', 'b' => [1, 2], 'c' => [1, 2, 'd' => [1, 2]]],
+                ['c' => [1, 'd' => [2, 1], 2], 'b' => [2, 1], 'a'],
                 0,
                 true,
             ],

--- a/tests/ArrayComparatorTest.php
+++ b/tests/ArrayComparatorTest.php
@@ -70,6 +70,12 @@ final class ArrayComparatorTest extends TestCase
                 ['true'],
                 [true],
             ],
+            [
+                ['a', 'b' => [1, 2]],
+                ['b' => [2, 1], 'a'],
+                0,
+                true,
+            ],
         ];
     }
 
@@ -114,6 +120,12 @@ final class ArrayComparatorTest extends TestCase
             [
                 ['false'],
                 [false],
+            ],
+            [
+                ['a', 'b' => [1, 2]],
+                ['b' => [2, 1], 'a', 'c' => 3],
+                0,
+                true,
             ],
         ];
     }


### PR DESCRIPTION
Fix:
- https://github.com/sebastianbergmann/comparator/issues/77

Relates:
 - https://github.com/sebastianbergmann/phpunit/issues/4455
 - https://github.com/sebastianbergmann/comparator/issues/44