### PR TITLE
Support for `BcMath\Number` objects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.3
+          php-version: 8.4
           coverage: none
 
       - name: Install dependencies with Composer

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,10 @@
 parameters:
     level: 10
+    phpVersion: 80402
     paths:
         - src
         - tests/unit
+
+    ignoreErrors:
+        # see https://github.com/phpstan/phpstan/issues/12099
+        - '~^Binary operation "[\+\-]" between BcMath\\Number and BcMath\\Number results in an error\.$~'

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -98,6 +98,7 @@ final class Factory
         $this->registerDefaultComparator(new SplObjectStorageComparator);
         $this->registerDefaultComparator(new ExceptionComparator);
         $this->registerDefaultComparator(new EnumerationComparator);
+        $this->registerDefaultComparator(new NumberComparator);
         $this->registerDefaultComparator(new ObjectComparator);
         $this->registerDefaultComparator(new ResourceComparator);
         $this->registerDefaultComparator(new ArrayComparator);

--- a/src/NumberComparator.php
+++ b/src/NumberComparator.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of sebastian/comparator.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\Comparator;
+
+use function assert;
+use function is_int;
+use function is_numeric;
+use function is_string;
+use function max;
+use function number_format;
+use BcMath\Number;
+
+final class NumberComparator extends ObjectComparator
+{
+    public function accepts(mixed $expected, mixed $actual): bool
+    {
+        return ($expected instanceof Number || $actual instanceof Number) &&
+            ($expected instanceof Number || is_int($expected) || is_string($expected) && is_numeric($expected)) &&
+            ($actual instanceof Number || is_int($actual) || is_string($actual) && is_numeric($actual));
+    }
+
+    /**
+     * @param array<mixed> $processed
+     *
+     * @throws ComparisonFailure
+     */
+    public function assertEquals(mixed $expected, mixed $actual, float $delta = 0.0, bool $canonicalize = false, bool $ignoreCase = false, array &$processed = []): void
+    {
+        if (!$expected instanceof Number) {
+            assert(is_string($expected) || is_int($expected));
+            $expected = new Number($expected);
+        }
+
+        if (!$actual instanceof Number) {
+            assert(is_string($actual) || is_int($actual));
+            $actual = new Number($actual);
+        }
+
+        $deltaNumber = new Number(number_format($delta, max($expected->scale, $actual->scale)));
+
+        if ($actual < $expected - $deltaNumber || $actual > $expected + $deltaNumber) {
+            throw new ComparisonFailure(
+                $expected,
+                $actual,
+                (string) $expected,
+                (string) $actual,
+                'Failed asserting that two Number objects are equal.',
+            );
+        }
+    }
+}

--- a/tests/unit/FactoryTest.php
+++ b/tests/unit/FactoryTest.php
@@ -9,7 +9,9 @@
  */
 namespace SebastianBergmann\Comparator;
 
+use function class_exists;
 use function tmpfile;
+use BcMath\Number;
 use DateTime;
 use DOMDocument;
 use Exception;
@@ -32,7 +34,7 @@ final class FactoryTest extends TestCase
     {
         $tmpfile = tmpfile();
 
-        return [
+        $instances = [
             [null, null, ScalarComparator::class],
             [null, true, ScalarComparator::class],
             [true, null, ScalarComparator::class],
@@ -76,6 +78,17 @@ final class FactoryTest extends TestCase
             [ExampleString::Foo, ExampleString::Bar, EnumerationComparator::class],
             [ExampleInt::Foo, ExampleInt::Bar, EnumerationComparator::class],
         ];
+
+        if (class_exists(Number::class)) {
+            $instances[] = [new Number('13.37'), new Number('47.11'), NumberComparator::class];
+            $instances[] = ['13.37', new Number('47.11'), NumberComparator::class];
+            $instances[] = [13, new Number('47.11'), NumberComparator::class];
+            $instances[] = [new Number('13.37'), new Number('47.11'), NumberComparator::class];
+            $instances[] = [new Number('13.37'), '47.11', NumberComparator::class];
+            $instances[] = [new Number('13.37'), 47, NumberComparator::class];
+        }
+
+        return $instances;
     }
 
     /**

--- a/tests/unit/NumberComparatorTest.php
+++ b/tests/unit/NumberComparatorTest.php
@@ -1,0 +1,149 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of sebastian/comparator.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\Comparator;
+
+use BcMath\Number;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\RequiresPhp;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+
+#[RequiresPhp('8.4')]
+#[RequiresPhpExtension('bcmath')]
+#[CoversClass(NumberComparator::class)]
+#[UsesClass(Comparator::class)]
+#[UsesClass(ComparisonFailure::class)]
+#[UsesClass(Factory::class)]
+final class NumberComparatorTest extends TestCase
+{
+    /**
+     * @return non-empty-list<array{0: mixed, 1: mixed}>
+     */
+    public static function acceptsSucceedsProvider(): array
+    {
+        $number        = new Number('13.37');
+        $anotherNumber = new Number('13');
+
+        return [
+            [$number, $anotherNumber],
+            [$number, '13'],
+            [$number, 13],
+            [$anotherNumber, $number],
+            ['13', $number],
+            [13, $number],
+        ];
+    }
+
+    /**
+     * @return non-empty-list<array{0: mixed, 1: mixed}>
+     */
+    public static function acceptsFailsProvider(): array
+    {
+        $number = new Number('13.37');
+
+        return [
+            [$number, null],
+            [$number, 'foo'],
+            [null, $number],
+            ['foo', $number],
+            [null, null],
+        ];
+    }
+
+    /**
+     * @return non-empty-list<array{0: int|Number|numeric-string, 1: int|Number|numeric-string, 2?: float}>
+     */
+    public static function assertEqualsSucceedsProvider(): array
+    {
+        return [
+            [new Number('13.37'), new Number('13.37')],
+            [new Number('13.37'), new Number('13.370000')],
+            ['13.37', new Number('13.370000')],
+            ['13.37', new Number('13.37')],
+            ['13.370000', new Number('13.37')],
+            [13, new Number('13')],
+            [new Number('13.37'), new Number('13.38'), .1],
+            ['13.37', new Number('13.38'), .1],
+            [13, new Number('13.38'), 1],
+            [new Number('47.11'), new Number('47.11'), .00001],
+        ];
+    }
+
+    /**
+     * @return non-empty-list<array{0: int|Number|numeric-string, 1: int|Number|numeric-string, 2?: float}>
+     */
+    public static function assertEqualsFailsProvider(): array
+    {
+        return [
+            [new Number('13'), new Number('13.37')],
+            ['13', new Number('13.37')],
+            [13, new Number('13.37')],
+            [new Number('13'), new Number('13.37'), .1],
+            ['13', new Number('13.37'), .1],
+            [13, new Number('13.37'), .1],
+            [new Number('47.11'), new Number('47.12'), .00001],
+        ];
+    }
+
+    public function testAcceptsSucceeds(): void
+    {
+        $this->assertTrue(
+            (new NumberComparator)->accepts(
+                new Number('1'),
+                new Number('2'),
+            ),
+        );
+    }
+
+    #[DataProvider('acceptsFailsProvider')]
+    public function testAcceptsFails(mixed $expected, mixed $actual): void
+    {
+        $this->assertFalse(
+            (new NumberComparator)->accepts($expected, $actual),
+        );
+    }
+
+    #[DataProvider('assertEqualsSucceedsProvider')]
+    public function testAssertEqualsSucceeds(int|Number|string $expected, int|Number|string $actual, float $delta = 0.0): void
+    {
+        $exception = null;
+
+        try {
+            (new NumberComparator)->assertEquals($expected, $actual, $delta);
+        } catch (ComparisonFailure $exception) {
+        }
+
+        $this->assertNull($exception, 'Unexpected ComparisonFailure');
+    }
+
+    #[DataProvider('assertEqualsSucceedsProvider')]
+    public function testAssertEqualsCanBeInverted(int|Number|string $actual, int|Number|string $expected, float $delta = 0.0): void
+    {
+        $exception = null;
+
+        try {
+            (new NumberComparator)->assertEquals($expected, $actual, $delta);
+        } catch (ComparisonFailure $exception) {
+        }
+
+        $this->assertNull($exception, 'Unexpected ComparisonFailure');
+    }
+
+    #[DataProvider('assertEqualsFailsProvider')]
+    public function testAssertEqualsFails(int|Number|string $expected, int|Number|string $actual, float $delta = 0.0): void
+    {
+        $this->expectException(ComparisonFailure::class);
+        $this->expectExceptionMessage('Failed asserting that two Number objects are equal.');
+
+        (new NumberComparator)->assertEquals($expected, $actual, $delta);
+    }
+}


### PR DESCRIPTION
This PR adds support for the new `BcMath\Number` value objects (php/php-src#13741). It allows comparing two numbers as well as comparing a number to an integer or a numeric string. The goal is to make the following assertions pass in PHPUnit:

```php
self::assertEquals(new Number('13.37'), new Number('13.370000'));
self::assertEquals('13.37', new Number('13.37'));
self::assertEquals(13, new Number('13.37'));
```

The PR also allows to compare to numbers with a delta.