### PR TITLE
Backport "Do not use SplObjectStorage methods that will be deprecated in PHP 8.5" to 5.0

### DIFF
--- a/src/SplObjectStorageComparator.php
+++ b/src/SplObjectStorageComparator.php
@@ -31,7 +31,7 @@ final class SplObjectStorageComparator extends Comparator
         $exporter = new Exporter;
 
         foreach ($actual as $object) {
-            if (!$expected->contains($object)) {
+            if (!$expected->offsetExists($object)) {
                 throw new ComparisonFailure(
                     $expected,
                     $actual,
@@ -43,7 +43,7 @@ final class SplObjectStorageComparator extends Comparator
         }
 
         foreach ($expected as $object) {
-            if (!$actual->contains($object)) {
+            if (!$actual->offsetExists($object)) {
                 throw new ComparisonFailure(
                     $expected,
                     $actual,

--- a/tests/SplObjectStorageComparatorTest.php
+++ b/tests/SplObjectStorageComparatorTest.php
@@ -40,12 +40,12 @@ final class SplObjectStorageComparatorTest extends TestCase
         $storage2 = new SplObjectStorage;
 
         $storage3 = new SplObjectStorage;
-        $storage3->attach($object1);
-        $storage3->attach($object2);
+        $storage3->offsetSet($object1);
+        $storage3->offsetSet($object2);
 
         $storage4 = new SplObjectStorage;
-        $storage4->attach($object2);
-        $storage4->attach($object1);
+        $storage4->offsetSet($object2);
+        $storage4->offsetSet($object1);
 
         return [
             [$storage1, $storage1],
@@ -63,11 +63,11 @@ final class SplObjectStorageComparatorTest extends TestCase
         $storage1 = new SplObjectStorage;
 
         $storage2 = new SplObjectStorage;
-        $storage2->attach($object1);
+        $storage2->offsetSet($object1);
 
         $storage3 = new SplObjectStorage;
-        $storage3->attach($object2);
-        $storage3->attach($object1);
+        $storage3->offsetSet($object2);
+        $storage3->offsetSet($object1);
 
         return [
             [$storage1, $storage2],
@@ -122,7 +122,7 @@ final class SplObjectStorageComparatorTest extends TestCase
         $this->expectExceptionMessage('Failed asserting that two objects are equal.');
 
         $t = new SplObjectStorage;
-        $t->attach(new stdClass);
+        $t->offsetSet(new stdClass);
 
         (new SplObjectStorageComparator)->assertEquals($t, new SplObjectStorage);
     }


### PR DESCRIPTION
Late backport of SplObjectStorage changes reated to PHP8.5 deprecations,
literally https://github.com/sebastianbergmann/comparator/commit/85c77556683e6eee4323e4c5468641ca0237e2e8.

Is this reasonable be done for 5.0 and phpunit 10.x ?
