### PR TITLE
Improve diff for canonicalized array comparison

### DIFF
--- a/src/ArrayComparator.php
+++ b/src/ArrayComparator.php
@@ -65,11 +65,18 @@ class ArrayComparator extends Comparator
             unset($remaining[$key]);
 
             if (!array_key_exists($key, $actual)) {
-                $expectedAsString .= sprintf(
-                    "    %s => %s\n",
-                    $exporter->export($key),
-                    $exporter->shortenedExport($value),
-                );
+                if ($canonicalize) {
+                    $expectedAsString .= sprintf(
+                        "    %s\n",
+                        $exporter->shortenedExport($value),
+                    );
+                } else {
+                    $expectedAsString .= sprintf(
+                        "    %s => %s\n",
+                        $exporter->export($key),
+                        $exporter->shortenedExport($value),
+                    );
+                }
 
                 $equal = false;
 
@@ -82,40 +89,71 @@ class ArrayComparator extends Comparator
                 /** @phpstan-ignore arguments.count */
                 $comparator->assertEquals($value, $actual[$key], $delta, $canonicalize, $ignoreCase, $processed);
 
-                $expectedAsString .= sprintf(
-                    "    %s => %s\n",
-                    $exporter->export($key),
-                    $exporter->shortenedExport($value),
-                );
+                if ($canonicalize) {
+                    $expectedAsString .= sprintf(
+                        "    %s\n",
+                        $exporter->shortenedExport($value),
+                    );
 
-                $actualAsString .= sprintf(
-                    "    %s => %s\n",
-                    $exporter->export($key),
-                    $exporter->shortenedExport($actual[$key]),
-                );
+                    $actualAsString .= sprintf(
+                        "    %s\n",
+                        $exporter->shortenedExport($actual[$key]),
+                    );
+                } else {
+                    $expectedAsString .= sprintf(
+                        "    %s => %s\n",
+                        $exporter->export($key),
+                        $exporter->shortenedExport($value),
+                    );
+
+                    $actualAsString .= sprintf(
+                        "    %s => %s\n",
+                        $exporter->export($key),
+                        $exporter->shortenedExport($actual[$key]),
+                    );
+                }
             } catch (ComparisonFailure $e) {
-                $expectedAsString .= sprintf(
-                    "    %s => %s\n",
-                    $exporter->export($key),
-                    $e->getExpectedAsString() !== '' ? $this->indent($e->getExpectedAsString()) : $exporter->shortenedExport($e->getExpected()),
-                );
+                if ($canonicalize) {
+                    $expectedAsString .= sprintf(
+                        "    %s\n",
+                        $e->getExpectedAsString() !== '' ? $this->indent($e->getExpectedAsString()) : $exporter->shortenedExport($e->getExpected()),
+                    );
 
-                $actualAsString .= sprintf(
-                    "    %s => %s\n",
-                    $exporter->export($key),
-                    $e->getActualAsString() !== '' ? $this->indent($e->getActualAsString()) : $exporter->shortenedExport($e->getActual()),
-                );
+                    $actualAsString .= sprintf(
+                        "    %s\n",
+                        $e->getActualAsString() !== '' ? $this->indent($e->getActualAsString()) : $exporter->shortenedExport($e->getActual()),
+                    );
+                } else {
+                    $expectedAsString .= sprintf(
+                        "    %s => %s\n",
+                        $exporter->export($key),
+                        $e->getExpectedAsString() !== '' ? $this->indent($e->getExpectedAsString()) : $exporter->shortenedExport($e->getExpected()),
+                    );
+
+                    $actualAsString .= sprintf(
+                        "    %s => %s\n",
+                        $exporter->export($key),
+                        $e->getActualAsString() !== '' ? $this->indent($e->getActualAsString()) : $exporter->shortenedExport($e->getActual()),
+                    );
+                }
 
                 $equal = false;
             }
         }
 
         foreach ($remaining as $key => $value) {
-            $actualAsString .= sprintf(
-                "    %s => %s\n",
-                $exporter->export($key),
-                $exporter->shortenedExport($value),
-            );
+            if ($canonicalize) {
+                $actualAsString .= sprintf(
+                    "    %s\n",
+                    $exporter->shortenedExport($value),
+                );
+            } else {
+                $actualAsString .= sprintf(
+                    "    %s => %s\n",
+                    $exporter->export($key),
+                    $exporter->shortenedExport($value),
+                );
+            }
 
             $equal = false;
         }

--- a/src/ArrayComparator.php
+++ b/src/ArrayComparator.php
@@ -9,6 +9,7 @@
  */
 namespace SebastianBergmann\Comparator;
 
+use function array_is_list;
 use function array_key_exists;
 use function assert;
 use function is_array;
@@ -17,6 +18,7 @@ use function is_float;
 use function is_int;
 use function is_object;
 use function is_string;
+use function ksort;
 use function serialize;
 use function sprintf;
 use function str_replace;
@@ -50,9 +52,18 @@ class ArrayComparator extends Comparator
         assert(is_array($expected));
         assert(is_array($actual));
 
+        $isList = false;
+
         if ($canonicalize) {
-            usort($expected, $this->compare(...));
-            usort($actual, $this->compare(...));
+            $isList = array_is_list($expected) && array_is_list($actual);
+
+            if ($isList) {
+                usort($expected, $this->compare(...));
+                usort($actual, $this->compare(...));
+            } else {
+                ksort($expected);
+                ksort($actual);
+            }
         }
 
         $remaining        = $actual;
@@ -65,7 +76,7 @@ class ArrayComparator extends Comparator
             unset($remaining[$key]);
 
             if (!array_key_exists($key, $actual)) {
-                if ($canonicalize) {
+                if ($canonicalize && $isList) {
                     $expectedAsString .= sprintf(
                         "    %s\n",
                         $exporter->shortenedExport($value),
@@ -89,7 +100,7 @@ class ArrayComparator extends Comparator
                 /** @phpstan-ignore arguments.count */
                 $comparator->assertEquals($value, $actual[$key], $delta, $canonicalize, $ignoreCase, $processed);
 
-                if ($canonicalize) {
+                if ($canonicalize && $isList) {
                     $expectedAsString .= sprintf(
                         "    %s\n",
                         $exporter->shortenedExport($value),
@@ -113,7 +124,7 @@ class ArrayComparator extends Comparator
                     );
                 }
             } catch (ComparisonFailure $e) {
-                if ($canonicalize) {
+                if ($canonicalize && $isList) {
                     $expectedAsString .= sprintf(
                         "    %s\n",
                         $e->getExpectedAsString() !== '' ? $this->indent($e->getExpectedAsString()) : $exporter->shortenedExport($e->getExpected()),
@@ -142,7 +153,7 @@ class ArrayComparator extends Comparator
         }
 
         foreach ($remaining as $key => $value) {
-            if ($canonicalize) {
+            if ($canonicalize && $isList) {
                 $actualAsString .= sprintf(
                     "    %s\n",
                     $exporter->shortenedExport($value),

--- a/tests/unit/ArrayComparatorTest.php
+++ b/tests/unit/ArrayComparatorTest.php
@@ -194,7 +194,7 @@ final class ArrayComparatorTest extends TestCase
     }
 
     /**
-     * @return non-empty-list<array{0: string, 1: array<string>, 2: array<string>, 3?: float, 4?: bool}>
+     * @return non-empty-array<array{0: string, 1: array<string>, 2: array<string>, 3?: float, 4?: bool}>
      */
     public static function assertEqualsFailsWithDiffProvider(): array
     {
@@ -224,6 +224,54 @@ final class ArrayComparatorTest extends TestCase
 ",
                 ['Some really long string that just keeps going and going and going but contains important clue XYZ and more behind'],
                 ['Some really long string that just keeps going and going and going but contains important clue HERE and more behind'],
+            ],
+            'canonicalized diff omits indices and shows only surplus element' => [
+                "
+--- Expected
++++ Actual
+@@ @@
+ Array (
+     'alpha'
++    'beta'
+     'gamma'
+ )
+",
+                ['alpha', 'gamma'],
+                ['alpha', 'beta', 'gamma'],
+                0.0,
+                true,
+            ],
+            'canonicalized diff omits indices and shows only missing element' => [
+                "
+--- Expected
++++ Actual
+@@ @@
+ Array (
+     'alpha'
+-    'beta'
+     'gamma'
+ )
+",
+                ['alpha', 'beta', 'gamma'],
+                ['alpha', 'gamma'],
+                0.0,
+                true,
+            ],
+            'canonicalized diff omits indices regardless of input order' => [
+                "
+--- Expected
++++ Actual
+@@ @@
+ Array (
+     'alpha'
++    'beta'
+     'gamma'
+ )
+",
+                ['gamma', 'alpha'],
+                ['gamma', 'alpha', 'beta'],
+                0.0,
+                true,
             ],
         ];
     }

--- a/tests/unit/ArrayComparatorTest.php
+++ b/tests/unit/ArrayComparatorTest.php
@@ -142,6 +142,13 @@ final class ArrayComparatorTest extends TestCase
                 0.0,
                 true,
             ],
+            // https://github.com/sebastianbergmann/comparator/pull/108
+            [
+                ['a', 'b' => [1, 2], 'c' => [1, 2, 'd' => [1, 2]]],
+                ['c' => [1, 'd' => [2, 1], 2], 'b' => [2, 1], 'a'],
+                0.0,
+                true,
+            ],
         ];
     }
 
@@ -190,11 +197,18 @@ final class ArrayComparatorTest extends TestCase
                 ['false'],
                 [false],
             ],
+            // https://github.com/sebastianbergmann/comparator/pull/108
+            [
+                ['a', 'b' => [1, 2]],
+                ['b' => [2, 1], 'a', 'c' => 3],
+                0.0,
+                true,
+            ],
         ];
     }
 
     /**
-     * @return non-empty-array<array{0: string, 1: array<string>, 2: array<string>, 3?: float, 4?: bool}>
+     * @return non-empty-array<array{0: string, 1: array<mixed>, 2: array<mixed>, 3?: float, 4?: bool}>
      */
     public static function assertEqualsFailsWithDiffProvider(): array
     {
@@ -270,6 +284,53 @@ final class ArrayComparatorTest extends TestCase
 ",
                 ['gamma', 'alpha'],
                 ['gamma', 'alpha', 'beta'],
+                0.0,
+                true,
+            ],
+            'canonicalized associative diff keeps keys and shows surplus element' => [
+                "
+--- Expected
++++ Actual
+@@ @@
+ Array (
+     0 => 'a'
+     'b' => [...]
++    'c' => 3
+ )
+",
+                ['a', 'b' => [1, 2]],
+                ['b' => [2, 1], 'a', 'c' => 3],
+                0.0,
+                true,
+            ],
+            'canonicalized associative diff keeps keys when value differs' => [
+                "
+--- Expected
++++ Actual
+@@ @@
+ Array (
+     'a' => 1
+-    'b' => 2
++    'b' => 3
+ )
+",
+                ['b' => 2, 'a' => 1],
+                ['a' => 1, 'b' => 3],
+                0.0,
+                true,
+            ],
+            'canonicalized associative diff keeps keys and shows missing element' => [
+                "
+--- Expected
++++ Actual
+@@ @@
+ Array (
+     'a' => 1
+-    'b' => 2
+ )
+",
+                ['b' => 2, 'a' => 1],
+                ['a' => 1],
                 0.0,
                 true,
             ],


### PR DESCRIPTION
The changes proposed here all relate to canonicalized array comparison (i.e. comparisons where the caller passes `$canonicalize = true`, as `assertEqualsCanonicalizing()` does in PHPUnit). Non-canonicalized comparisons are unaffected.

### 1. Associative and multidimensional arrays are now handled correctly

Without these changes, canonicalization always called `usort()` on both arrays. `usort()` reindexes its input as a list, which silently destroyed the string keys of associative arrays before they were compared. The same happened recursively for inner arrays. As a result, canonicalized comparison of associative or mixed-shape arrays could produce misleading diffs or, in some cases, falsely report equality of arrays whose keys actually differed.

With these changes, the comparator detects whether both operands are lists (`array_is_list()`):

- Both operands are lists: sorted with `usort()`, as before
- Anything else: sorted by key with `ksort()`, so string keys are preserved and the values are compared key by key

This is decided per array, so nested mixes, e.g. a list containing associative sub-arrays, or vice versa, are handled correctly at each level.

### 2. Cleaner diff output for canonicalized list comparisons

Because canonicalization sorts list elements, the original numeric indices become meaningless.

Without these changes, they were printed nevertheless in the diff, producing noisy output where the `0 =>`, `1 =>`, `2 =>` markers shifted around and obscured the actual difference.

With these changes, the diff for two canonicalized lists now shows just the values:

```
 Array (
     'alpha'
+    'beta'
     'gamma'
 )
```

instead of the previous form with reindexed `N => value` entries. Associative-array diffs still display their keys, since those are meaningful.