### PR TITLE
bump dependency on sebastian/diff 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "prefer-stable": true,
     "require": {
         "php": ">=8.4",
-        "sebastian/diff": "^8.0",
+        "sebastian/diff": "^8.1",
         "sebastian/exporter": "^8.0",
         "ext-dom": "*",
         "ext-mbstring": "*"


### PR DESCRIPTION
Because test suite failing with 8.0
```
PHPUnit 13.1.0 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.5.5RC1
Configuration: /dev/shm/BUILD/php-sebastian-comparator8-8.1.0-build/comparator-8.1.0/phpunit.xml

F..............................................................  63 / 411 ( 15%)
............................................................... 126 / 411 ( 30%)
............................................................... 189 / 411 ( 45%)
............................................................... 252 / 411 ( 61%)
............................................................... 315 / 411 ( 76%)
............................................................... 378 / 411 ( 91%)
.................................                               411 / 411 (100%)

Time: 00:00.037, Memory: 8.00 MB

There was 1 failure:

1) SebastianBergmann\Comparator\ComparisonFailureTest::testCustomContextLines
Failed asserting that 12 is greater than 12.

/dev/shm/BUILD/php-sebastian-comparator8-8.1.0-build/comparator-8.1.0/tests/unit/ComparisonFailureTest.php:80

FAILURES!
Tests: 411, Assertions: 535, Failures: 1.

```