### PR TITLE
`ComparisonFailure` cannot be serialized when stack trace contains non-serializable objects

### DIFF
--- a/src/ComparisonFailure.php
+++ b/src/ComparisonFailure.php
@@ -33,6 +33,32 @@ final class ComparisonFailure extends RuntimeException
         $this->actualAsString   = $actualAsString;
     }
 
+    /**
+     * @return array{expected: mixed, actual: mixed, expectedAsString: string, actualAsString: string, message: string}
+     */
+    public function __serialize(): array
+    {
+        return [
+            'expected'         => $this->expected,
+            'actual'           => $this->actual,
+            'expectedAsString' => $this->expectedAsString,
+            'actualAsString'   => $this->actualAsString,
+            'message'          => $this->message,
+        ];
+    }
+
+    /**
+     * @param array{expected: mixed, actual: mixed, expectedAsString: string, actualAsString: string, message: string} $data
+     */
+    public function __unserialize(array $data): void
+    {
+        $this->expected         = $data['expected'];
+        $this->actual           = $data['actual'];
+        $this->expectedAsString = $data['expectedAsString'];
+        $this->actualAsString   = $data['actualAsString'];
+        $this->message          = $data['message'];
+    }
+
     public function getActual(): mixed
     {
         return $this->actual;

--- a/tests/_fixture/NonSerializableClass.php
+++ b/tests/_fixture/NonSerializableClass.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of sebastian/comparator.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\Comparator;
+
+use Error;
+
+final class NonSerializableClass
+{
+    public function __serialize(): array
+    {
+        throw new Error('This class cannot be serialized');
+    }
+
+    public function __unserialize(array $data): void
+    {
+    }
+}

--- a/tests/unit/ComparisonFailureTest.php
+++ b/tests/unit/ComparisonFailureTest.php
@@ -9,6 +9,9 @@
  */
 namespace SebastianBergmann\Comparator;
 
+use function ini_set;
+use function serialize;
+use function unserialize;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Small;
 use PHPUnit\Framework\Attributes\UsesClass;
@@ -56,5 +59,54 @@ final class ComparisonFailureTest extends TestCase
         $failure = new ComparisonFailure('a', 'b', '', '', 'test');
         $this->assertSame('', $failure->getDiff());
         $this->assertSame('test', $failure->toString());
+    }
+
+    public function testCanBeSerializedAndUnserialized(): void
+    {
+        $failure = new ComparisonFailure(
+            "\nA\n",
+            "\nB\n",
+            "|\nA\n",
+            "|\nB\n",
+            'Test message',
+        );
+
+        /** @var ComparisonFailure $restored */
+        $restored = unserialize(serialize($failure));
+
+        $this->assertInstanceOf(ComparisonFailure::class, $restored);
+        $this->assertSame($failure->getExpected(), $restored->getExpected());
+        $this->assertSame($failure->getActual(), $restored->getActual());
+        $this->assertSame($failure->getExpectedAsString(), $restored->getExpectedAsString());
+        $this->assertSame($failure->getActualAsString(), $restored->getActualAsString());
+        $this->assertSame($failure->getMessage(), $restored->getMessage());
+        $this->assertSame($failure->getDiff(), $restored->getDiff());
+        $this->assertSame($failure->toString(), $restored->toString());
+    }
+
+    public function testCanBeSerializedWhenStackTraceContainsNonSerializableObject(): void
+    {
+        $previousIgnoreArgs = ini_set('zend.exception_ignore_args', '0');
+
+        try {
+            $failure = $this->createFailureWithNonSerializableTraceArgument(new NonSerializableClass);
+
+            /** @var ComparisonFailure $restored */
+            $restored = unserialize(serialize($failure));
+        } finally {
+            ini_set('zend.exception_ignore_args', $previousIgnoreArgs);
+        }
+
+        $this->assertInstanceOf(ComparisonFailure::class, $restored);
+        $this->assertSame('a', $restored->getExpected());
+        $this->assertSame('b', $restored->getActual());
+        $this->assertSame('a', $restored->getExpectedAsString());
+        $this->assertSame('b', $restored->getActualAsString());
+        $this->assertSame('test', $restored->getMessage());
+    }
+
+    private function createFailureWithNonSerializableTraceArgument(NonSerializableClass $instance): ComparisonFailure
+    {
+        return new ComparisonFailure('a', 'b', 'a', 'b', 'test');
     }
 }


### PR DESCRIPTION
`ComparisonFailure` can now be safely `serialize()`d and `unserialize()`d, even when its stack trace would otherwise contain references to non-serializable objects (such as `PDO` connections, file handles wrapped in objects, or other resources captured as function arguments on the call stack).

`ComparisonFailure` extends `RuntimeException` and therefore inherits a stack trace. When PHPUnit runs tests in process isolation mode, failures are serialized to transport them between processes. If any frame in the trace captured an argument whose class refuses serialization, the entire `serialize()` call throws and the test result cannot be transported. This surfaces as a confusing error rather than the actual assertion failure.

This affected, for example, tests that exercise database code: a `PDO` instance passed as a method argument would end up referenced in the trace and break process-isolated runs.

Serializing a `ComparisonFailure` now preserves only the data needed to describe the failure: the expected and actual values (raw and stringified) and the failure message. The unserialized object continues to report the same diff and the same `toString()` output as the original.

The stack trace, file, and line are not preserved across a serialize/unserialize round-trip. In practice this matches what most consumers already do with a transported failure, render its message and diff, and removes the foot-gun where unrelated objects on the stack could prevent transport entirely.
