### PR TITLE
Use by-value comparison for closures

### DIFF
--- a/src/ClosureComparator.php
+++ b/src/ClosureComparator.php
@@ -39,9 +39,9 @@ final class ClosureComparator extends Comparator
         $expectedReflector = new ReflectionFunction($expected);
         $actualReflector   = new ReflectionFunction($actual);
 
-        if ($this->sameDeclaration($expectedReflector, $actualReflector) &&
-            $this->sameBinding($expectedReflector, $actualReflector) &&
-            $this->sameCapturedState($expectedReflector, $actualReflector)) {
+        if ($this->declarationIsEqual($expectedReflector, $actualReflector) &&
+            $this->bindingIsEqual($expectedReflector, $actualReflector) &&
+            $this->capturedStateIsEqual($expectedReflector, $actualReflector)) {
             return;
         }
 
@@ -70,7 +70,7 @@ final class ClosureComparator extends Comparator
         );
     }
 
-    private function sameDeclaration(ReflectionFunction $expected, ReflectionFunction $actual): bool
+    private function declarationIsEqual(ReflectionFunction $expected, ReflectionFunction $actual): bool
     {
         return $expected->getName() === $actual->getName() &&
             $expected->getFileName() === $actual->getFileName() &&
@@ -78,7 +78,7 @@ final class ClosureComparator extends Comparator
             $expected->getEndLine() === $actual->getEndLine();
     }
 
-    private function sameBinding(ReflectionFunction $expected, ReflectionFunction $actual): bool
+    private function bindingIsEqual(ReflectionFunction $expected, ReflectionFunction $actual): bool
     {
         if ($expected->getClosureScopeClass()?->getName() !== $actual->getClosureScopeClass()?->getName()) {
             return false;
@@ -90,7 +90,7 @@ final class ClosureComparator extends Comparator
         );
     }
 
-    private function sameCapturedState(ReflectionFunction $expected, ReflectionFunction $actual): bool
+    private function capturedStateIsEqual(ReflectionFunction $expected, ReflectionFunction $actual): bool
     {
         return $this->recursivelyEqual(
             $expected->getClosureUsedVariables(),

--- a/src/ClosureComparator.php
+++ b/src/ClosureComparator.php
@@ -32,13 +32,18 @@ final class ClosureComparator extends Comparator
         assert($expected instanceof Closure);
         assert($actual instanceof Closure);
 
-        /** @phpstan-ignore equal.notAllowed */
-        if ($expected == $actual) {
+        if ($expected === $actual) {
             return;
         }
 
         $expectedReflector = new ReflectionFunction($expected);
         $actualReflector   = new ReflectionFunction($actual);
+
+        if ($this->sameDeclaration($expectedReflector, $actualReflector) &&
+            $this->sameBinding($expectedReflector, $actualReflector) &&
+            $this->sameCapturedState($expectedReflector, $actualReflector)) {
+            return;
+        }
 
         $expectedFilename  = $expectedReflector->getFileName();
         $expectedStartLine = $expectedReflector->getStartLine();
@@ -63,5 +68,44 @@ final class ClosureComparator extends Comparator
                 $actualStartLine,
             ),
         );
+    }
+
+    private function sameDeclaration(ReflectionFunction $expected, ReflectionFunction $actual): bool
+    {
+        return $expected->getName() === $actual->getName() &&
+            $expected->getFileName() === $actual->getFileName() &&
+            $expected->getStartLine() === $actual->getStartLine() &&
+            $expected->getEndLine() === $actual->getEndLine();
+    }
+
+    private function sameBinding(ReflectionFunction $expected, ReflectionFunction $actual): bool
+    {
+        if ($expected->getClosureScopeClass()?->getName() !== $actual->getClosureScopeClass()?->getName()) {
+            return false;
+        }
+
+        return $this->recursivelyEqual(
+            $expected->getClosureThis(),
+            $actual->getClosureThis(),
+        );
+    }
+
+    private function sameCapturedState(ReflectionFunction $expected, ReflectionFunction $actual): bool
+    {
+        return $this->recursivelyEqual(
+            $expected->getClosureUsedVariables(),
+            $actual->getClosureUsedVariables(),
+        );
+    }
+
+    private function recursivelyEqual(mixed $expected, mixed $actual): bool
+    {
+        try {
+            $this->factory()->getComparatorFor($expected, $actual)->assertEquals($expected, $actual);
+        } catch (ComparisonFailure) {
+            return false;
+        }
+
+        return true;
     }
 }

--- a/tests/_fixture/ClosureFixture.php
+++ b/tests/_fixture/ClosureFixture.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types=1);
+/*
+ * This file is part of sebastian/comparator.
+ *
+ * (c) Sebastian Bergmann <sebastian@phpunit.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianBergmann\Comparator;
+
+use Closure;
+
+final class ClosureFixture
+{
+    public static function staticNoCapture(): Closure
+    {
+        return static fn (): int => 1;
+    }
+
+    /**
+     * @return Closure(): int
+     */
+    public static function staticCapturingInt(int $captured): Closure
+    {
+        return static fn (): int => $captured;
+    }
+
+    /**
+     * @return Closure(): array{0: int, 1: string}
+     */
+    public static function staticCapturingTwo(int $a, string $b): Closure
+    {
+        return static fn (): array => [$a, $b];
+    }
+
+    /**
+     * @return Closure(): mixed
+     */
+    public static function staticCapturingMixed(mixed $captured): Closure
+    {
+        return static fn (): mixed => $captured;
+    }
+
+    public static function staticAlternativeNoCapture(): Closure
+    {
+        return static fn (): int => 1;
+    }
+
+    public function __construct(public int $value = 0)
+    {
+    }
+
+    public function nonStaticReturningOne(): Closure
+    {
+        return function (): int
+        {
+            return $this->value;
+        };
+    }
+}

--- a/tests/unit/ClosureComparatorTest.php
+++ b/tests/unit/ClosureComparatorTest.php
@@ -9,7 +9,9 @@
  */
 namespace SebastianBergmann\Comparator;
 
+use function assert;
 use Closure;
+use DateTimeImmutable;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Small;
@@ -18,10 +20,17 @@ use PHPUnit\Framework\TestCase;
 
 #[CoversClass(ClosureComparator::class)]
 #[UsesClass(ComparisonFailure::class)]
+#[UsesClass(DateTimeComparator::class)]
 #[UsesClass(Factory::class)]
+#[UsesClass(ObjectComparator::class)]
+#[UsesClass(ArrayComparator::class)]
+#[UsesClass(ScalarComparator::class)]
+#[UsesClass(TypeComparator::class)]
 #[Small]
 final class ClosureComparatorTest extends TestCase
 {
+    private ClosureComparator $comparator;
+
     /**
      * @return non-empty-list<array{0: mixed, 1: mixed}>
      */
@@ -57,7 +66,7 @@ final class ClosureComparatorTest extends TestCase
     }
 
     /**
-     * @return non-empty-list<array{0: Closure, 1: Closure}>
+     * @return non-empty-array<string, array{Closure, Closure}>
      */
     public static function assertEqualsSucceedsProvider(): array
     {
@@ -66,12 +75,32 @@ final class ClosureComparatorTest extends TestCase
         };
 
         return [
-            [$f, $f],
+            'identical closure instance'    => [$f, $f],
+            'same declaration, no captures' => [
+                ClosureFixture::staticNoCapture(),
+                ClosureFixture::staticNoCapture(),
+            ],
+            'same declaration, equal scalar capture' => [
+                ClosureFixture::staticCapturingInt(7),
+                ClosureFixture::staticCapturingInt(7),
+            ],
+            'same declaration, multiple equal captures' => [
+                ClosureFixture::staticCapturingTwo(1, 'x'),
+                ClosureFixture::staticCapturingTwo(1, 'x'),
+            ],
+            'same declaration, captured object compares equal recursively' => [
+                ClosureFixture::staticCapturingMixed(new DateTimeImmutable('2024-01-01T00:00:00+00:00')),
+                ClosureFixture::staticCapturingMixed(new DateTimeImmutable('2024-01-01T00:00:00+00:00')),
+            ],
+            'same declaration, bound $this objects compare equal recursively' => [
+                (new ClosureFixture(1))->nonStaticReturningOne(),
+                (new ClosureFixture(1))->nonStaticReturningOne(),
+            ],
         ];
     }
 
     /**
-     * @return non-empty-list<array{0: Closure, 1: Closure}>
+     * @return non-empty-array<string, array{Closure, Closure}>
      */
     public static function assertEqualsFailsProvider(): array
     {
@@ -83,16 +112,46 @@ final class ClosureComparatorTest extends TestCase
         {
         };
 
+        $rescopedNoCapture = Closure::bind(ClosureFixture::staticNoCapture(), null, Author::class);
+
+        assert($rescopedNoCapture instanceof Closure);
+
         return [
-            [$f, $g],
+            'different declaration site, identical body' => [
+                ClosureFixture::staticNoCapture(),
+                ClosureFixture::staticAlternativeNoCapture(),
+            ],
+            'inline closures declared at different lines' => [$f, $g],
+            'same declaration, differing scalar capture'  => [
+                ClosureFixture::staticCapturingInt(1),
+                ClosureFixture::staticCapturingInt(2),
+            ],
+            'same declaration, captured object compares not equal' => [
+                ClosureFixture::staticCapturingMixed(new DateTimeImmutable('2024-01-01T00:00:00+00:00')),
+                ClosureFixture::staticCapturingMixed(new DateTimeImmutable('2025-01-01T00:00:00+00:00')),
+            ],
+            'same declaration, differing scope class' => [
+                ClosureFixture::staticNoCapture(),
+                $rescopedNoCapture,
+            ],
+            'same declaration, bound $this objects compare not equal' => [
+                (new ClosureFixture(1))->nonStaticReturningOne(),
+                (new ClosureFixture(2))->nonStaticReturningOne(),
+            ],
         ];
+    }
+
+    protected function setUp(): void
+    {
+        $this->comparator = new ClosureComparator;
+        $this->comparator->setFactory(new Factory);
     }
 
     #[DataProvider('acceptsSucceedsProvider')]
     public function testAcceptsSucceeds(mixed $expected, mixed $actual): void
     {
         $this->assertTrue(
-            (new ClosureComparator)->accepts($expected, $actual),
+            $this->comparator->accepts($expected, $actual),
         );
     }
 
@@ -100,17 +159,17 @@ final class ClosureComparatorTest extends TestCase
     public function testAcceptsFails(mixed $expected, mixed $actual): void
     {
         $this->assertFalse(
-            (new ClosureComparator)->accepts($expected, $actual),
+            $this->comparator->accepts($expected, $actual),
         );
     }
 
     #[DataProvider('assertEqualsSucceedsProvider')]
-    public function testAssertEqualsSucceeds(mixed $expected, mixed $actual): void
+    public function testAssertEqualsSucceeds(Closure $expected, Closure $actual): void
     {
         $exception = null;
 
         try {
-            (new ClosureComparator)->assertEquals($expected, $actual);
+            $this->comparator->assertEquals($expected, $actual);
         } catch (ComparisonFailure $exception) {
         }
 
@@ -118,13 +177,13 @@ final class ClosureComparatorTest extends TestCase
     }
 
     #[DataProvider('assertEqualsFailsProvider')]
-    public function testAssertEqualsFails(mixed $expected, mixed $actual): void
+    public function testAssertEqualsFails(Closure $expected, Closure $actual): void
     {
         try {
-            (new ClosureComparator)->assertEquals($expected, $actual);
+            $this->comparator->assertEquals($expected, $actual);
         } catch (ComparisonFailure $e) {
             $this->assertStringMatchesFormat(
-                'Failed asserting that closure declared at %sClosureComparatorTest.php:%d is equal to closure declared at %sClosureComparatorTest.php:%d.',
+                'Failed asserting that closure declared at %s:%d is equal to closure declared at %s:%d.',
                 $e->getMessage(),
             );
 
@@ -145,7 +204,7 @@ final class ClosureComparatorTest extends TestCase
         };
 
         try {
-            (new ClosureComparator)->assertEquals($f, $g);
+            $this->comparator->assertEquals($f, $g);
         } catch (ComparisonFailure $e) {
             $this->assertStringMatchesFormat(
                 'Closure Object #%d ()',


### PR DESCRIPTION
Version 7.0 introduced `ClosureComparator`, which made PHPUnit's `assertEquals()` actually compare closures instead of unconditionally returning `true`. The implementation used PHP's `==`, which on closures reduces to identity comparison: two distinct `Closure` instances never compare equal under `==`, even if they were produced from the same source expression with the same captured state.

The result, reported in #129, is that `assertEquals()` on closures behaves like identity comparison in practice. Real-world code that constructs the same closure on every call now fails `assertEquals()` whenever the closure is created twice. This behaviour is stricter than the user-facing semantics of `assertEquals()` and stricter than any reasonable definition of "two closures are equal."

It is important to note that this comparator is not used by PHPUnit's `assertSame()` which uses PHP's `===` directly.

In the issue #129 thread, @Ocramius made the point that motivated this pull request:

> Data point here: in `assertSame()`, it would be acceptable to compare closures by their ID, but `assertEquals()` cannot do per-id comparison.
>
> The only way I can see this working is by looking at the serialized comparison of closures, effectively using by-val comparison of closures.

Two closures with the same declaration site and the same captured state must compare equal; two closures whose captures differ must not. The current implementation gets the first case wrong because `==` on closures is per-instance.

@Ocramius is not arguing for a revert to the pre-7.0 "all closures are equal" behaviour; that behaviour is wrong for the inverse reason. He is arguing that the current implementation has the wrong algorithm and needs to be replaced with a by-value comparison.

`ClosureComparator::assertEquals()` now performs by-value comparison through `ReflectionFunction`. Two closures compare equal if:

1. `getName()`, `getFileName()`, `getStartLine()`, and `getEndLine()` all match. Two closures that come from different source locations are categorically different, even if their bodies happen to be identical.
2. Bound scope class names match, and bound `$this` values compare equal under the rest of the comparator stack (recursing through `Factory`).
3. The arrays returned by `ReflectionFunction::getClosureUsedVariables()` compare equal under the rest of the comparator stack.

Steps 2 and 3 delegate back into the comparator `Factory`, so captured `DateTimeImmutable`s use `DateTimeComparator`, captured nested objects use `ObjectComparator`, captured nulls hit `TypeComparator`, and so on. This is what makes it by-value rather than by-identity.

PHP's `serialize()` cannot serialize closures, so "serialized comparison" in @Ocramius' phrasing is implemented here as "extract the captured state via Reflection and compare that recursively through the existing comparator chain."

Two closures with identical bodies declared at different source locations (`fn () => null` declared in file A and `fn () => null` declared in file B, for example) are not equal under this implementation. Reaching equality there would require comparing the actual compiled function code (opcodes or bytecode), which is neither portable across PHP versions nor exposed by Reflection. We treat the declaration site as part of the closure's identity. This matches @Ocramius' example, where all three closures share a declaration site and differ only in captures.

Closures wrapping internal callables created via `Closure::fromCallable('strlen')` will compare equal to each other (same name, no file/line), but the formatted failure message for mismatched cases still relies on `getFileName()`/`getStartLine()` being non-`false`. This limitation is unchanged from the current implementation.
