### PR TITLE
Expose detection of closure comparisons

### DIFF
--- a/src/ClosureComparator.php
+++ b/src/ClosureComparator.php
@@ -29,6 +29,8 @@ final class ClosureComparator extends Comparator
 
     public function assertEquals(mixed $expected, mixed $actual, float $delta = 0.0, bool $canonicalize = false, bool $ignoreCase = false): void
     {
+        $this->factory()->recordClosureComparison();
+
         assert($expected instanceof Closure);
         assert($actual instanceof Closure);
 

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -32,7 +32,8 @@ final class Factory
     private array $defaultComparators = [];
 
     /** @var positive-int */
-    private int $contextLines = 3;
+    private int $contextLines               = 3;
+    private bool $closureComparisonOccurred = false;
 
     public static function getInstance(): self
     {
@@ -62,6 +63,24 @@ final class Factory
     public function setContextLines(int $contextLines): void
     {
         $this->contextLines = $contextLines;
+    }
+
+    /**
+     * @internal this method is called by ClosureComparator and is not part of the consumer-facing API
+     */
+    public function recordClosureComparison(): void
+    {
+        $this->closureComparisonOccurred = true;
+    }
+
+    public function closureComparisonOccurred(): bool
+    {
+        return $this->closureComparisonOccurred;
+    }
+
+    public function resetClosureComparisonTracking(): void
+    {
+        $this->closureComparisonOccurred = false;
     }
 
     public function getComparatorFor(mixed $expected, mixed $actual): Comparator

--- a/tests/unit/ClosureComparatorTest.php
+++ b/tests/unit/ClosureComparatorTest.php
@@ -195,6 +195,21 @@ final class ClosureComparatorTest extends TestCase
         $this->fail('Expected ComparisonFailure to be thrown');
     }
 
+    public function testRecordsClosureComparisonInFactory(): void
+    {
+        $factory    = new Factory;
+        $comparator = new ClosureComparator;
+        $comparator->setFactory($factory);
+
+        $closure = static function (): void
+        {
+        };
+
+        $comparator->assertEquals($closure, $closure);
+
+        $this->assertTrue($factory->closureComparisonOccurred());
+    }
+
     public function testAsStringComparisonFormat(): void
     {
         $f = static function (): void

--- a/tests/unit/FactoryTest.php
+++ b/tests/unit/FactoryTest.php
@@ -180,4 +180,80 @@ final class FactoryTest extends TestCase
 
         $this->assertSame(5, $factory->contextLines());
     }
+
+    public function testClosureComparisonTrackingIsDisabledByDefault(): void
+    {
+        $factory = new Factory;
+
+        $this->assertFalse($factory->closureComparisonOccurred());
+    }
+
+    public function testClosureComparisonIsRecordedWhenTwoClosuresAreCompared(): void
+    {
+        $closure = static function (): void
+        {
+        };
+
+        $factory = new Factory;
+        $factory->getComparatorFor($closure, $closure)->assertEquals($closure, $closure);
+
+        $this->assertTrue($factory->closureComparisonOccurred());
+    }
+
+    public function testClosureComparisonIsRecordedWhenClosuresAreNestedInArrays(): void
+    {
+        $closure = static function (): void
+        {
+        };
+
+        $expected = ['callback' => $closure];
+        $actual   = ['callback' => $closure];
+
+        $factory = new Factory;
+        $factory->getComparatorFor($expected, $actual)->assertEquals($expected, $actual);
+
+        $this->assertTrue($factory->closureComparisonOccurred());
+    }
+
+    public function testClosureComparisonIsRecordedWhenClosuresAreNestedInObjects(): void
+    {
+        $closure = static function (): void
+        {
+        };
+
+        $expected           = new stdClass;
+        $expected->callback = $closure;
+
+        $actual           = new stdClass;
+        $actual->callback = $closure;
+
+        $factory = new Factory;
+        $factory->getComparatorFor($expected, $actual)->assertEquals($expected, $actual);
+
+        $this->assertTrue($factory->closureComparisonOccurred());
+    }
+
+    public function testClosureComparisonIsNotRecordedWhenNoClosuresAreCompared(): void
+    {
+        $expected = [1];
+        $actual   = [1];
+
+        $factory = new Factory;
+        $factory->getComparatorFor($expected, $actual)->assertEquals($expected, $actual);
+
+        $this->assertFalse($factory->closureComparisonOccurred());
+    }
+
+    public function testClosureComparisonTrackingCanBeReset(): void
+    {
+        $closure = static function (): void
+        {
+        };
+
+        $factory = new Factory;
+        $factory->getComparatorFor($closure, $closure)->assertEquals($closure, $closure);
+        $factory->resetClosureComparisonTracking();
+
+        $this->assertFalse($factory->closureComparisonOccurred());
+    }
 }


### PR DESCRIPTION
`ClosureComparator` decides closure equality with a heuristic: two closures are "equal" when they share the same declaration site, the same bound `$this`, and equal captured `use` variables. That can quietly return equal for closures that are not meaningfully interchangeable.

PHPUnit wants to surface this and raise a (possibly opt-out) warning when `assertEquals()` (and the other comparator-based assertions) end up comparing closures so users learn that they rely on fragile closure comparison rather than getting a silent pass.

Equality assertions run constantly, often over large arrays and object graphs. PHPUnit must not pay a second full traversal of the operands just to ask "was a closure involved?" as that tax would be paid on every assertion, including the overwhelming majority that contain no closures at all.

The comparison already walks the entire graph: `ArrayComparator` / `ObjectComparator` dispatch every nested node through `Factory::getComparatorFor()`, which routes closure-vs-closure nodes to `ClosureComparator`. So the cheap place to detect closure comparison is inside the comparison that's already happening. We can let `ClosureComparator` record the fact, and let the consumer read it afterward. No second traversal, effectively free.

`Factory` gains a per-instance boolean flag and a small API (all additive, `Factory` is under the backward compatibility promise, so this is BC-safe):

- `recordClosureComparison()` sets the flag. Marked `@internal`; it's the write side, called only by `ClosureComparator`
- `closureComparisonOccurred()` is the consumer-facing query
- `resetClosureComparisonTracking()` clears the flag so a consumer can scope it to a single comparison

`ClosureComparator::assertEquals()` calls `$this->factory()->recordClosureComparison()` as its first statement. Because every default comparator is registered into the same `Factory` instance via `setFactory()`, the flag set deep inside a nested comparison is visible to the `Factory` the consumer holds — even when the closures are buried inside arrays or object properties.

The flag is set to `true` only when a closure is compared against a closure. This is exactly the silent, heuristic-driven case worth warning about. The flag is not set to `true` for one-sided cases (a closure compared against a scalar / `null`, or under a key that exists on only one side), because those already produce a visible assertion failure. So the cheap signal targets the genuinely silent risk, not the cases that already fail loudly.